### PR TITLE
usunięty shoplov.in

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -617,7 +617,6 @@ saturn.pl###nl_modal
 saturn.pl###nl_overlay
 seb-tv.pl##center
 shinden.pl###ad-player
-shoplov.in##.slide
 showup.tv##div.bottom-baner
 showup.tv##div.top-baner
 sieradz.com.pl##.box
@@ -953,7 +952,6 @@ zycietoprzygoda.pl##[class^="tws_"]
 ||haloursynow.pl/img/banery/
 ||mojaolesnica.pl/reklamy/
 ||www.comperialead.pl/upload/$image
-||data.shoplov.in/$subdocument
 ||tvgry.pl/images/tapeta_reklama/$image
 !
 !


### PR DESCRIPTION
W nawiązaniu do rozmowy z Wojtkiem Zającem proszę o usunięcie shoplov.in z listy. Jeśli jakaś konkretna galeria budzi zastrzeżenia prosimy o kontakt, zareagujemy natychmiast.
