### PR TITLE
benchmark.pl

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -186,6 +186,24 @@ autocentrum.pl##.homepage-add-left
 autodoradca.pl##.banner-top
 bankier.pl##[class$="Adv"]
 bebzol.com###right-col > .r-stick-box
+benchmark.pl###adblock-info
+benchmark.pl###header > nav > .categories
+benchmark.pl###newsletterMail
+benchmark.pl###sidebar > .newsletter.block > h4
+benchmark.pl###sidebar > div:nth-of-type(11)
+||apis.google.com/u/0/_/widget/render/badge?usegapi=1&size=badge&hl=pl&origin=http%3A%2F%2Fbenchmark.pl&url=https%3A%2F%2Fplus.google.com%2F110788993637079925953&gsrc=3p&ic=1&jsh=m%3B%2F_%2Fscs%2Fapps-static%2F_%2Fjs%2Fk%3Doz.gapi.pl.WisHSCIB8qg.O%2Fm%3D__features__%2Fam%3DAQ%2Frt%3Dj%2Fd%3D1%2Frs%3DAGLTcCNke0n3W835c8ZBezLmzUWW2Nc70g
+benchmark.pl###___plus_0
+benchmark.pl###sidebar > div:nth-of-type(10)
+benchmark.pl###latestTopics
+benchmark.pl###similarTopics
+benchmark.pl###pointTopics
+benchmark.pl###productCompareSimilar
+benchmark.pl###marketplaceProductBox 
+benchmark.pl###socialEntryBar
+benchmark.pl###inTop
+benchmark.pl###wideBody > .fiveTilesAndLinks
+benchmark.pl###wideBody > .textCenter.pointTopics
+benchmark.pl###wideBody > .noSidePadding.productCompareSimilar
 bezuzyteczna.pl,zumi.pl##[class^="special"]
 bez-cenzury24.pl##[div^="ips-popup"]
 bitcoin.pl,rightclick.pl##.custom


### PR DESCRIPTION
Filtry umożliwiają NORMALNE przeglądanie ww. strony 
blokują niechciane "spamy" oraz linki do profili społecznościowych 
