### PR TITLE
Przywrócenie adnotacji i przycisku "udostępnij"

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -1161,14 +1161,3 @@ wykop.pl##div.doodle
 *wykop.pl/static/nowywykoppl/css/prawykop.css$stylesheet
 *wykop.pl/*/paylink_$image,domain=www.wykop.pl
 ||www.wykop.pl/paylink/emiter/$image,domain=www.wykop.pl
-!
-!
-!-----------------------Youtube: Other Annoyances------------------
-! Removes all annotations in videos
-||youtube.com/annotations_invideo?$object-subrequest
-! HTML5 version
-youtube.com##.video-annotations
-! Removes sharing tab below videos
-||youtube.com/share_ajax?action_get_share_box=1&video_id=$xmlhttprequest
-youtube.com##.action-panel-trigger[role="button"][data-trigger-for="action-panel-share"]
-youtube.com##.yt-uix-button[data-trigger-for="action-panel-share"]


### PR DESCRIPTION
Usunięcie przycisku "udostępnij" oraz adnotacji z filmów na Youtube mija się z celem.
Adblock powinien blokować reklamy, a nie normalne funkcje strony.

Przycisk "SHARE" jest bardzo przydatny do np. pobierania skróconego adresu filmu oraz linkowania do aktualnej minuty.

Adnotacje są wciąż używane do linkowania, wstawiania poprawek do filmów lub informowania widzów o jakiś zmianach.

Nie widzę powodu dla usuwania tak przydatnej **funkcjonalności** strony.
Polskie filtry powinny blokować reklamy na polskich stronach, a nie zmieniać działania międzynarodowych serwisów.
