### PR TITLE
wykop.pl

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -1426,22 +1426,19 @@ facet.wp.pl,teleshow.wp.pl##div[class^="_"]:matches-css(background-image: url("d
 !
 !
 !--------------------------Rules wykop.pl-------------!
-!https://gist.githubusercontent.com/dmnmrzk/372968e8f51f6d7d2dc7/raw/8714607e19c2fa6f62d81bfd9da475d5edec1b3c/wykop-adblock.txt!
 wykop.pl###autopromotion
-www.wykop.pl##.blacklisted
 wykop.pl###fixedBox
+wykop.pl###fixedBoxIdent
 wykop.pl###itemsStream:not(.touch-content) .article:not(.dC)
-wykop.pl###nav > .annotation.type-alert
-www.wykop.pl##ul#dyingLinksBox
 wykop.pl##.baner-mobile
-www.wykop.pl##article.slim
-wykop.pl##li.payentry
-wykop.pl##div.doodle
-*wykop.pl/*/paylink_$image,domain=www.wykop.pl
-||www.wykop.pl/paylink/emiter/$image,domain=www.wykop.pl
-||nowy.wykop.pl/static/nowywykoppl/sponsors/$image,stylesheet,script
-wykop.pl##a[class*=screening]
-||wykop.pl/tracker/emiter/$image,domain=www.wykop.pl
+wykop.pl##div.r-block:has(:scope > .baner-mobile)
+wykop.pl##div.r-block:has(:scope > [id^=bmone2n-])
+wykop.pl##li.link:has(.adsbygoogle)
+wykop.pl##li.link:has(a[href*='wykop.pl/market'])
+wykop.pl##li.link:has(a[href*='wykop.pl/paylink'])
+wykop.pl##li.link:has(a[href*='wykop.pl/reklama'])
+||imgwykop.pl/*/paylink_$image,domain=www.wykop.pl
+||wykop.pl/paylink/emiter/$image,domain=www.wykop.pl
 !
 !
 !--------------------------Rules unblock protection------------!


### PR DESCRIPTION
Wyczyściłem trochę filtry dla wykopu. Usunąłem te filtry które blokują elementy które nie powinny być blokowane. Na przykład wpisy z czarnej listy. To nie są reklamy, takie rzeczy to ludzie sobie we własnym zakresie mogą zrobić jak chcą. 

Dodałem też trochę bardziej surowe filtrowanie linków reklamowych.

Jedyna upierdliwa rzecz to #dyingLinksBox który nie powinien być blokowany, bo to nie są reklamy. Tylko jeden element (czasem) jest w nim reklamą i załatwia to filtr `wykop.pl##li.link:has(a[href*='wykop.pl/market'])` ale has nie działa na adblockplus więc tam nie ukryje tego linka. Ale nie ma innej możliwości zablokowania samego linka, niestety. IMO nie powinno być całe #dyingLinksBox blokowane szczególnie, że na ublocku nie ma tego problemu. Ale to już do waszej decyzji.