### PR TITLE
Update Social & Cookies (6.6.2018)

### DIFF
--- a/adblock_social_filters/adblock_social_list.txt
+++ b/adblock_social_filters/adblock_social_list.txt
@@ -1,5 +1,5 @@
 [Adblock Plus 2.0]
-! Checksum: ZAY0GYHwNiUgEkix0lWEmQ
+! Checksum: ZeS/ilrSw1ewb/k98nKwag
 ! Title: Polskie Filtry Społecznościowe
 ! Polish Social Filters
 ! Codename: Social
@@ -7,8 +7,8 @@
 ! Required: Do poprawnego działania wymagana jest lista Fanboy's Social Blocking List!
 ! Collaborators: blocker999, hawkeye116477, xxcriticxx, KonoromiHimaries, RikoDEV, krystian3w
 ! Homepage: https://www.certyficate.it/
-! Version: 201806051702
-! Last modified: Tue, 05 Jun 2018, 17:02:32 UTC+02
+! Version: 201806061142
+! Last modified: Wed, 06 Jun 2018, 11:42:43 UTC+02
 ! Expires: 2 days
 ! Support:
 !   GitHub => https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: CC BY-NC-SA 4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0)
 ! Copyright © 2018 Certyficate IT & Polish Filters Team
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock/
-! v.201806051702 aktualizacja: wto, 05 cze 2018, 17:02:32 UTC+02 
+! v.201806061142 aktualizacja: śro, 06 cze 2018, 11:42:43 UTC+02 
 !
 !
 ! Dołączenie listy uzupełniającej do uBlocka i AdGuarda, by użytkownicy nie musieli jej subskrybować
@@ -805,6 +805,7 @@ bet-at-home.com##.teaser-social-media
 bezpiecznywtlumie.pl##.fa-google-plus
 bezprawnik.pl##.columns.show-for-large.large-1 > p:nth-of-type(2)
 beztajemnic.pwn.pl###menu-item-50
+bezwypadkowy.net##li.schide:nth-child(n+2):nth-child(-n+4), .jf_sidebuttons, .rt-grid-3:nth-of-type(3)
 biedronka.pl##.see-fb
 bieganieuskrzydla.pl###text-2
 bielskiedrogi.pl###block-block-1
@@ -872,6 +873,7 @@ catzilla.com##.btn-block.btn-sm.btn-default.btn.cbConnectButtonTwitter.cbConnect
 catzilla.com##.btn-block.btn-sm.btn-primary.btn.cbConnectButtonFacebook.cbConnectButtonIconText.cbConnectButton
 cdahd.pl##.rdt, .social-share-round
 cdp.pl##.fmenu-col.col4
+cenowarka.pl###fb-btn-img
 centrumkomputerowe.eu###imFooter > div
 centrumkomputerowe.eu###imHeader > div:nth-of-type(4)
 centrumparis.pl##.social_footer_2
@@ -1057,6 +1059,7 @@ elportal.pl###text-4
 elubaczow.com###text-34, #text-35
 emisja.tv##.header-signbtn
 empik.com##.empikFooter__social
+emt-systems.pl##.top-main > li:nth-of-type(13), .social.footer-menu
 em.kielce.pl###socialico > ul
 em.kielce.pl##.module_prawa:nth-of-type(1)
 em.kielce.pl##.module_prawa:nth-of-type(4)
@@ -1137,6 +1140,7 @@ foxkomputer.pl##.topFb
 freelancer.pl##.FooterNew-social
 fronda.pl##.rating-container
 frsih.pl##.stickSocial
+funduszpomerania.pl##.custom > ul > li:nth-of-type(1)
 funnygames.pl##.extra-share
 funnygames.pl##.share-options
 funtech.pl###mSliderMsg
@@ -1250,6 +1254,8 @@ hotelforumlublin.pl###google_icon
 how2play.pl##.social-description
 hpba.pl##.social__media
 hubkolektyw.pl##.uk-grid.uk-flex-center.uk-child-width-auto
+iautomatyka.pl##.youtube.pf-sociallinks-item, .mpc-effect-side--none
+iautomatyka.pl#?#.h2_belka:-abp-contains(Społeczność)
 idg.pl##.social_con, ul:nth-of-type(2) > li, .footer_social_links > ul
 ikrotoszyn.pl##.facebookfield
 inbook.pl##a[href="http://plus.google.com/u/0/105997578854872087403/posts"]
@@ -1293,6 +1299,7 @@ jagodnik.pl##a[href="https://twitter.com/jagodnik_pl"]
 jakrobicmarketing.pl###twitter-follow-2, #gcz_facebook_page_like-2, .share-buttons
 jakzrobicwexcelu.pl###custom_html-6
 jaworzno.pl##.widget_sfp_page_plugin_widget
+jbzdy.pl##.btn-send-messenger
 jezuici.pl##.et_pb_with_border.et_pb_text_8.et_pb_text_align_left.et_pb_bg_layout_dark.et_pb_module.et_pb_text
 joomla.pl###user21
 jsystems.pl##h4:nth-of-type(2)
@@ -1430,6 +1437,7 @@ mediaexpert.pl##.mfp-inline-holder.mfp-s-ready.mfp-container
 medianarodowe.com##.clearfix.widget_radium_newsletter.widget > p
 medianarodowe.com##.custom_footer > p
 medme.pl##.medme__header__social
+medpolonia.pl##.helper-yt
 menworld.pl##.to-top-trans.relative.left.fly-soc-head, .goog-soc, .tum-soc
 merlin.pl##.grid__col--quarter.b-footer__in-touch.grid__col > .b-footer__title
 metaloweszafkigrzewcze.eu##.kac-sm-gplus
@@ -1702,6 +1710,7 @@ polsl.pl##tr:nth-of-type(3) > .shortcutsLink:nth-of-type(2)
 polsl.pl##tr:nth-of-type(3) > .shortcutsLink:nth-of-type(5)
 polsl.pl##tr:nth-of-type(5) > .shortcutsImg:nth-of-type(1)
 polsl.pl##tr:nth-of-type(5) > .shortcutsLink:nth-of-type(2)
+polszczyzna.pl##.eltdf-icon-shortcode, .textwidget > h4
 polvision.com##.foot_search_share
 polygamia.pl###polysocial
 polygamia.pl###sidebar-footer-top
@@ -1849,6 +1858,7 @@ samequizy.pl##.hidemobile.col-3:nth-of-type(1)
 samoloty.pl##.custom > p:nth-of-type(2)
 samoloty.pl##.custom > p:nth-of-type(3)
 samsung.com##.gb-footer__sns-list
+satkurier.pl###sky_left_container
 saturn.pl##.s-productFooter_social
 sawataxi.pl##.oNasSocIcons, .oNasSocName
 schronisko.olsztyn.pl###wysuwane
@@ -2023,6 +2033,7 @@ trybawaryjny.pl##.widget_text.col-4.widget:nth-of-type(3)
 trybun.org.pl##.uwl_instagram_widget_wrap, .widget_simplecatch_social_widget
 tugazeta.pl###face_button, #snap_button
 tui.pl##.col-lg-3.col-sm-6.col-xs-12:nth-of-type(4)
+tuzdrowie.pl##.tr-facebook
 tvgry.pl##.mnu-ico-fb, .mnu-ico-yt, .mnu-ico-tw, .tvgry-main-right-promo
 tvn24bis.pl##.title-wrapper > .social, .fbClassicBox, .forum-header-box > h3
 tvn24.pl##.fbClassicBox
@@ -2294,6 +2305,7 @@ zyciepabianic.pl###facebook
 ||m.lm.pl/gfx/facebook_zaloguj.png
 ||m.lm.pl/gfx/instagram.png
 ||naekranie.pl/wp-content/plugins/socialfans-counter/assets/js/socialfans-script.js
+||natatry.pl/images/icon-insta.png
 ||news.androidlista.pl/wp-content/themes/tema/gplusicon.jpg
 ||pakerzy.org/gfx/fb.png
 ||pay-card.pl/wp-content/uploads/2017/06/social-bg.jpg
@@ -2381,6 +2393,7 @@ naekranie.pl#@#.share-buttons
 naszpradnik.pl#@#.menu-social
 rta24.eu#@#.social-bottom
 rynek-kolejowy.pl#@#.socialIcons
+satkurier.pl#@##menu_social
 tabletowo.pl#@#.social_icon
 tabletowo.pl#@#.top-social
 tvgry.pl,gameplay.pl#@#.social-16

--- a/cookies_filters/adblock_cookies.txt
+++ b/cookies_filters/adblock_cookies.txt
@@ -1,13 +1,13 @@
 [Adblock Plus 2.0]
-! Checksum: co7wJ+UHXlQ5IC/HKL2X3A
+! Checksum: ovkmmfS+kJNcUh5L8fVEBQ
 ! Title: Polskie Filtry RODO-Ciasteczkowe
 ! Polish GDPR-Cookies Filters
 ! Codename: Cookies
 ! Description: Filtry ukrywające i blokujące komunikaty dot. ciasteczek i polityki prywatności/RODO.
 ! Collaborators: F4z, xxcriticxx, blocker999, hawkeye116477, krystian3w
 ! Homepage: https://www.certyficate.it/
-! Version: 201806051659
-! Last modified: Tue, 05 Jun 2018, 16:59:48 UTC+02
+! Version: 201806061201
+! Last modified: Wed, 06 Jun 2018, 12:01:36 UTC+02
 ! Expires: 2 days
 ! Support:
 !   Email => errors@certyficate.it
@@ -16,7 +16,7 @@
 ! License: CC BY-NC-SA 4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0)
 ! Copyright © 2018 Certyficate IT & Polish Filters Team
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock/
-! v.201806051659 aktualizacja: wto, 05 cze 2018, 16:59:48 UTC+02
+! v.201806061201 aktualizacja: śro, 06 cze 2018, 12:01:36 UTC+02
 !
 !
 ! Dołączenie listy uzupełniającej do uBlocka i AdGuarda, by użytkownicy nie musieli jej subskrybować
@@ -1096,7 +1096,9 @@ apra.pl###popup-overlay
 astar.czest.pl##.lean-overlay
 audioteka.com##.anonymousToSConsent_mask
 autocentrum.pl##.hello-rodo
+autodna.pl##.privacy_policy-info 
 autogielda.pl##.modal-backdrop
+automo.pl,autobaza.pl###rodo, .rodoButtonUp
 auto-swiat.pl###termsPopup
 bryk.pl,interia.pl,pokazywarka.pl##.rodo-mini
 certum.pl##.spu-bg, .spu-box
@@ -1109,12 +1111,15 @@ durszlak.pl##.shadow.privacy-layer
 dziennikwschodni.pl##.rodo-alert
 ekstraklasa.tv##.cmp-app_gdpr
 elka.pl,elka.tv###RODOZgoda
+emt-systems.pl###rodoBG
 epoznan.pl###rodo-info-box
+epuap.gov.pl###rodo-modal
 fantasy.ekstraklasa.tv###rodo-info
 filmweb.pl##.rodo__overlay
 firmy.lu###privacy_info_overlay, #privacy_info_content
 foreca.pl###ckieconsent
-gazetalubuska.pl,dziennikbaltycki.pl,gs24.pl,echodnia.eu,pomorska.pl,nto.pl,gazetakrakowska.pl,sportowy24.pl,dzienniklodzki.pl,dziennikpolski24.pl,gloswielkopolski.pl,gol24.pl,nowiny24.pl,warszawa.naszemiasto.pl,kurierlubelski.pl,expressilustrowany.pl,gazetawroclawska.pl,poranny.pl,dziennikzachodni.pl,nowosci.com.pl,gk24.pl,to.com.pl,polskatimes.pl,expressbydgoski.pl,telemagazyn.pl###cross-dialog
+funduszpomerania.pl###eprivacyModal, .modal-backdrop
+gazetalubuska.pl,dziennikbaltycki.pl,gs24.pl,echodnia.eu,pomorska.pl,nto.pl,gazetakrakowska.pl,sportowy24.pl,dzienniklodzki.pl,dziennikpolski24.pl,gloswielkopolski.pl,gol24.pl,nowiny24.pl,warszawa.naszemiasto.pl,kurierlubelski.pl,expressilustrowany.pl,gazetawroclawska.pl,poranny.pl,dziennikzachodni.pl,nowosci.com.pl,gk24.pl,to.com.pl,polskatimes.pl,expressbydgoski.pl,telemagazyn.pl,naszemiasto.pl###cross-dialog
 gb.pl###rdModal
 gieldarolna.pl##.rodo
 gofin.pl###formalAgreementModal, #modalBackdrop
@@ -1133,14 +1138,19 @@ londynek.net##.jd-rodo
 lotto.pl###klauzula_informacyjna_nakladka
 lubimyczytac.pl###TB_window, #TB_overlay
 lublin112.pl###privacy_info_content, #privacy_info_overlay
+mall.pl##consent-panel
 meble.com.pl,archiconnect.pl,lazienka.pl,najlepszedomy.pl,mamkuchnie.pl###axn
 medme.pl###ccc
+medpolonia.pl###bannerPopup
 m.benchmark.pl###private-policy-popup
 naekranie.pl###modal-rodo-info, .reveal-modal-bg
 natemat.pl,aszdziennik.pl,mamadu.pl,innpoland.pl,warszawawpigulce.pl##div[class^="app_gdpr"]
 neonet.pl##.rodo-info__content, .rodo-info__overlay
 neosite.pl,ppe.pl,terazmuzyka.pl###rodo-overlay
-niezalezna.pl,gpcodziennie.pl/###swsoverlay, #swsmodal
+niezalezna.pl,gpcodziennie.pl###swsoverlay, #swsmodal
+nokaut.pl###GDPRModal
+odo24.pl##.rodo-body
+optyczne.pl###id01
 player.pl##.modal-dialog
 pl##.cmp-app_gdpr:not(body):not(html)
 pl##.rodo-accept:not(body):not(html)
@@ -1173,6 +1183,7 @@ wzp.pl###myrodoinfo
 /rhododendron/css/rhododendron-popup.css$domain=wpolityce.pl|wgospodarce.pl|wpolsce.pl
 /_sess/rodo.js
 ||assets.allegrostatic.com/opbox-rodo-consent-modal/index*.css$domain=allegro.pl
+||assets.goldenline.io/assets/user/profilingAgreement.*.js
 ||a.wpimg.pl/a/i/stg/wpjslib-chunk-consent-form.js
 ||cdn.rp.pl/rodo-agreement-popup/rodo-agreement-popup.min.js
 ||cookie.avt.pl/cookie-noscript

--- a/cookies_filters/cookies_uB_AG.txt
+++ b/cookies_filters/cookies_uB_AG.txt
@@ -1,11 +1,11 @@
-! Checksum: 8dyI9xRgVnwup480Ca7rmA
+! Checksum: EX+HXAktxJ9uiKplc/NkRA
 ! Title: Polskie Filtry RODO-Ciasteczkowe - uzupełnienie do uBlocka i AdGuarda
 ! Polish GDPR-Cookies Filters - Supplement for uBlock & AdGuard
 ! Codename: Cookies - supplement
 ! Collaborators: F4z, hawkeye116477
 ! Homepage: https://www.certyficate.it/
-! Version: 201806051419
-! Last modified: Tue, 05 Jun 2018, 14:19:12 UTC+02
+! Version: 201806061142
+! Last modified: Wed, 06 Jun 2018, 11:42:42 UTC+02
 ! Expires: 2 days
 ! Support:
 !   Email => errors@certyficate.it
@@ -14,7 +14,7 @@
 ! License: CC BY-NC-SA 4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0)
 ! Copyright © 2018 Certyficate IT & Polish Filters Team
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock/
-! v.201806051419 aktualizacja: wto, 05 cze 2018, 14:19:12 UTC+02 
+! v.201806061142 aktualizacja: śro, 06 cze 2018, 11:42:42 UTC+02 
 !
 !
 ! Komunikaty ciasteczkowe i dziury
@@ -68,7 +68,7 @@ unileverfoodsolutions.pl##.js-cookie-wall
 !
 ! Popupy - polityka prywatności/RODO
 alltube.tv,alltube.pl###rodo-popup, .modal-backdrop
-alltube.tv,alltube.pl,zakopane.info,fryzomania.pl,obywatel.gov.pl,tuwroclaw.com,infoplanet.pl,tulodz.com,gokf.gda.pl,gdansk.pl,hbogo.pl,e-sochaczew.pl,pultusk24.pl,ogloszenia.plock.pl##.modal-open:style(overflow: auto !important; padding-right: 0px !important;)
+alltube.tv,alltube.pl,zakopane.info,fryzomania.pl,obywatel.gov.pl,tuwroclaw.com,infoplanet.pl,tulodz.com,gokf.gda.pl,gdansk.pl,e-sochaczew.pl,pultusk24.pl,ogloszenia.plock.pl,tuzdrowie.pl##.modal-open:style(overflow: auto !important; padding-right: 0px !important;)
 budownictwo.pl###rodoLayer, .modal-backdrop
 budownictwo.pl##.modal-open:style(overflow: auto !important;)
 dobrzemieszkaj.pl###axn
@@ -81,6 +81,7 @@ gazetabilgoraj.pl##.popmake-overlay
 gazetabilgoraj.pl##.pum-open:style(overflow: auto !important;)
 gdansk.pl##.rodo, .modal-backdrop
 gokf.gda.pl##.rodo, .modal-backdrop
+hbogo.pl##body:style(overflow: auto !important; padding-right: 0px !important;)
 hbogo.pl##.banner-overlay
 infoplanet.pl###rodo, .modal-backdrop
 lovekrakow.pl###modal-rodo, .modal-backdrop
@@ -94,6 +95,7 @@ oko.press##.is-reveal-open:style(overflow: auto !important;)
 oko.press##.reveal-overlay
 portalspozywczy.pl,sadyogrody.pl,rynekzdrowia.pl,farmer.pl,dlahandlu.pl,propertynews.pl,portalsamorzadowy.pl,rynekaptek.pl,infodent24.pl,housemarket.pl,pulshr.pl,propertydesign.pl,rynekseniora.pl,ckl.pl,ptwp.pl,promocjada.pl,wnp.pl,frsih.pl##.rodo
 portalspozywczy.pl,sadyogrody.pl,rynekzdrowia.pl,farmer.pl,dlahandlu.pl,propertynews.pl,portalsamorzadowy.pl,rynekaptek.pl,infodent24.pl,housemarket.pl,pulshr.pl,propertydesign.pl,rynekseniora.pl,ckl.pl,ptwp.pl,promocjada.pl,wnp.pl,frsih.pl##.windowOpen:style(overflow: auto !important;)
+tuzdrowie.pl###popupModal, .modal-backdrop
 wagrowczanie.pl##.showRodo
 wsensie.pl,wsensie.tv###policy
 wsensie.pl,wsensie.tv##.policy-open section:style(filter: none !important;)


### PR DESCRIPTION
Wszystko z etykietą Social i Cookies można zamknąć prócz antyweba.
Podziękowania dla @krystian3w.
