### PR TITLE
 Update Advert Filters to version 2018072602 

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 ! Wsparcie: https://patronite.pl/polskiefiltry
-! Last modified: 25 July 2018
+! Last modified: 26 July 2018
 ! Expires: 1 day
-! Version: 2018072502
+! Version: 2018072602
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -17,10 +17,10 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2018072502 aktualizacja: śr, 25 lipca 2018, 13:33:00
+! v.2018072602 aktualizacja: czw, 26 lipca 2018, 14:05:00
 !
 !
-!-----------------------Integration list with uBlock & Adguard-----------------------!
+!-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
 !#if ext_ublock
 !#include adblock_ublock.txt
 !#endif
@@ -307,6 +307,7 @@ alawar.pl##.b-game-list__bnr-title
 alilove.pl##.widget_text:nth-of-type(3)
 alilove.pl##.widget_text:nth-of-type(5)
 allaboutmusic.pl###tie-block_707
+allans.pl##.buy_btn, .interesting
 allegro.pl###coins-banner
 allegro.pl###installments-banner-container
 allegro.pl###main_page_hr_980_180
@@ -495,6 +496,7 @@ brodnica.net##.stopka
 brodnica.net##[href^="/banery/click.php"]
 brodnica.net##td:nth-of-type(3) > table > tbody > tr:nth-of-type(1) > td:nth-of-type(2)
 bryk.pl,zvami.tv,debica24.eu,telewizjazary.pl,korsokolbuszowskie.pl,kociewiak.pl,cooltura24.co.uk,portalpomorza.pl,tvobiektyw.pl,debica24.eu,echotygodnik.info,damitv.pl,ct.jaworzno.pl##[class^="advert-"]
+brytol.com###text-3
 btc-sms.eu##.banner
 budmatauto.pl##.popup-content, .popup-bg
 budnet.pl##a[href^="https://"] > IMG
@@ -882,7 +884,7 @@ fili.tv,fili.cc##divo, #divlol
 fili.tv,fili.cc,centrumdruku3d.pl##a[href^="https://goo.gl/"]
 filmpolski.pl##.obrazek_bez_ramki
 films4free.pl##.M2U3OGQ4ZGY1
-filmweb.pl###iframe, .clickArea, .screening-content, .topBillboard, .BILLBOARD, [id^="sad_"], .clickableAdBG, #screening, [id$="_ifame"], [id^="sas_"], div[class] > [href*="/click"], [src$=".html"]
+filmweb.pl###iframe, .clickArea, .screening-content, .topBillboard, .BILLBOARD, [id^="sad_"], .clickableAdBG, #screening, [id$="_ifame"], [id^="sas_"], div[class] > [href*="/click"], [src$=".html"], .advBtn
 filmweb.pl##[id*="iframe"]
 fishing-mart.com.pl##td:nth-of-type(6) > .norm11:nth-of-type(4)
 flarrow.pl##[class^="td_block_wrap td_block_text_with_title td_uid_"]
@@ -1554,7 +1556,7 @@ mikrokontroler.pl##TD[style*="background-image: url(\"http://mikrokontroler.pl/"
 mikrokontroler.pl##[id^="block-simpleads-ad"]
 mikrokontroler.pl,24legnica.pl,polonia-peterborough.uk###text-5
 milanos.pl#?#.post:-abp-contains(reklama)
-minecraft-list.pl##.smutnazabajpg_container.transparent_container, #a.pleaserinonoblokerino_display
+minecraft-list.pl##.smutnazabajpg_container.transparent_container, #a.pleaserinonoblokerino_display, div.gitjestgit_container
 minecraft.org.pl##.stone-module.well-sm.well:nth-of-type(4)
 mistrzowie.org###services_box
 mistrzowie.org##.clearfix.lbox.pic:nth-of-type(5)
@@ -2049,8 +2051,7 @@ prostoomuzyce.pl##[id^="block-views-banery-block"]
 prostozmostu.net###ecoeconomy
 prostozmostu.net###nmb-BusyBox
 prostozmostu.pl###column-right
-proto.pl###block-block-1
-proto.pl###zone-header-wrapper
+proto.pl###block-block-1, #block-block-9, #zone-header-wrapper
 prv.pl###container
 prv.pl##.menu
 przedszkola.edu.pl##.sidebar__widget:nth-of-type(2)
@@ -2485,7 +2486,7 @@ trybawaryjny.pl###bottom-bar
 trybawaryjny.pl##.description.post-content > p:nth-of-type(3)
 trybi.pl###main_content_section > div[style=" text-align: center; height: 260px;"]
 trybi.pl##.bannerInner
-trybun.org.pl##[id*="_adspace_widget"]
+trybun.org.pl##[id*="_adspace_widget"], #_dropslide1
 trybunaczestochowska.pl,animalistka.pl,pojon.pl,300polityka.pl###text-2
 tryton.com.pl##[id^="banner"]
 tubagliwic.pl##.active.visible
@@ -3096,6 +3097,7 @@ zywiecinfo.pl##.promoted
 ||lib.onet.pl/s.csr/external/iframe$script,subdocument
 ||lidl.pl/statics/lidl-pl/ds_img/layout/tapeta_$image
 ||link.batuu.pl/$script
+||listaserwerowmc.pl/*baner$image
 ||lubartow24.pl/f/*.gif$image
 ||lubartow24.pl/f/navb*.jpg$image
 ||lubin.pl/wp-content/themes/supernews-provider/adrotate_group.php
@@ -3139,6 +3141,7 @@ zywiecinfo.pl##.promoted
 ||niebiescy.pl/bild/$image
 ||nokaut.pl/wigetyflash/$object
 ||nowiny.rybnik.pl/baner/$image
+||nqp0852y7r.com/e6/52/26/e652267829a86c98499016a18555c207.js$script,domain=internetowa.ws
 ||nuteczki.eu/templates/KlubowaMuza/images/pobierz.png$image
 ||ocdn.eu/*.html$subdocument,domain=sniadaniezkadra.onet.pl
 ||ocs-pl.oktawave.com/*/reklamy$subdocument,domain=spidersweb.pl
@@ -3502,6 +3505,7 @@ dziwnekomiksy.pl###adbk
 e-dokument.org,znaki.vxm.pl#@##banner_ad
 egarwolin.pl###TXhkUvZljBCga
 fly4free.pl##.warnadblk
+forum.komputerswiat.pl#@##ks_breaking_news
 forum.vw-passat.pl###ct_i
 fotoblogia.pl,gadzetomania.pl,wp.pl,autokult.pl,komorkomania.pl,medycyna24.pl,smaczneblogi.pl##.modal__body-adblock
 gazetakrakowska.pl##.md-ub
@@ -3996,7 +4000,7 @@ wp.tv##.y9xe8qn
 !
 !32#--------------------------WP element block------------!
 ||i.wp.pl/*/stg/wpjslib-nojq.js$script,domain=www.dobreprogramy.pl
-||v.wpimg.pl/$image,domain=money.pl|open.fm|autokult.pl
+||v.wpimg.pl/$image,domain=open.fm|autokult.pl
 ||v.wpimg.pl/$media,redirect=noopmp3-0.1s,domain=wp.pl|~www.wp.pl|autokult.pl|parenting.pl|echirurgia.pl|money.pl|o2.pl|portal.abczdrowie.pl|komorkomania.pl|fotoblogia.pl|gadzetomania.pl|pudelek.pl|jejswiat.pl|medycyna24.pl|dobreprogramy.pl
 ||wpkoszyk.wp.pl/api/koszyk$xmlhttprequest
 ||xml.enovatis.pl/mrdsl/json.php$xmlhttprequest,domain=turystyka.wp.pl
@@ -4051,7 +4055,7 @@ www.wp.pl##[data-st-area="Gwiazdy-prawa"] > div > div
 www.wp.pl##[data-st-area="Mototech-prawa"] > div[class]
 www.wp.pl##DIV[style="position: relative; display: block;"] > DIV[style*="overflow: hidden; "]
 www.wp.pl##[id^="section_"]:not(#section_trends) > div:not([class]) > div:not([class]):not([id])
-www.wp.pl##div[class*=" "]:empty:not(.btnmute):not(.volsliderbg):not([style]):not([id]):not([img]):not([src])
+!www.wp.pl##div[class*=" "]:empty:not(.btnmute):not(.volsliderbg):not([style]):not([id]):not([img]):not([src])
 www.wp.pl##[id^="sgwp_screening_"]
 www.wp.pl###newsfeed-player-column[class^="_3"] > DIV[class^="sc-"]
 www.wp.pl###section_celebrities > div:nth-of-type(1)
@@ -4144,6 +4148,7 @@ autofakty.pl##.widget_text.widget
 bielskiedrogi.pl###block-block-9, #block-views-reklamy-block
 bieznie-treningowe.pl,inforiders.pl,paleosmak.pl###text-2
 blogprezesa.pl,kryptowaluty.info.pl,litecoin.pl##.aligncenter
+blogujmy24.pl##.blogu-widget, .blogu-text, #custom_html-3
 blogujmy24.pl,tarnow.in###text-3
 businesstraveller.pl##.widget-clear.widget
 craftportal.pl###text-13
@@ -4196,6 +4201,7 @@ rytmklawiatury.pl,chelmno.com.pl###text-19
 slupca.pl##.a-76.g-single > div
 smartage.pl###media_image-3
 smartage.pl,wronieckibazar.pl,mobirank.pl,historykon.pl,wolnekonopie.org,korso.pl###custom_html-2
+socialpress.pl###text-29
 stacja-tluszcz.pl###text-35
 stopnadwadze.pl###text-4
 stopnadwadze.pl###text-html-widget-10
@@ -4204,7 +4210,7 @@ supertydzien.pl##.widget.row:nth-of-type(12)
 technologiczna.pl##.alignnone
 technowinki24.pl###black-studio-tinymce-2
 tomaszowski.com.pl###text-15
-toyotaklub.org.pl,wiadomoscipodgorze.pl,mymma.pl###text-6
+toyotaklub.org.pl,wiadomoscipodgorze.pl,mymma.pl,niebezpiecznik.pl###text-6
 trybunaczestochowska.pl##body > div:nth-of-type(1) > center
 trybunaczestochowska.pl###foot-leader
 trybunaczestochowska.pl###text-4, #text-6, #text-9, #text-11

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -3,9 +3,9 @@
 ! Codename: Official - supplement for AdGuard
 ! Collaborators: F4z, FadeMind, hawkeye116477
 ! Homepage: https://www.certyficate.it/
-! Last modified: 25 July 2018
+! Last modified: 26 July 2018
 ! Expires: 2 days
-! Version: 2018072501
+! Version: 2018072601
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -13,7 +13,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018072501 aktualizacja: śr, 25 lipca 2018, 13:49:00
+! v.2018072601 aktualizacja: czw, 26 lipca 2018, 13:20:00
 !
 !
 ! http://alltube.tv/
@@ -165,6 +165,7 @@ pilkanozna.pl##.index_bg_top:style(top: auto!important;)
 podkarpackahistoria.pl###main-nav1:style(height: 50px !important;)
 portal.abczdrowie.pl##.article__side__stickblock:style(position: absolute!important; left: -3000px!important;)
 portal.abczdrowie.pl##.article__textbox:style(position: absolute!important; left: -3000px!important;)
+radom24.pl###pojemnik-strony:style(margin-top: 0 !important;)
 spidersweb.pl##.playstation.wall-bg:style(background: none!important)
 tabletowo.pl###main_header:style(margin-top: 0px!important;)
 tv-wschod.pl##.widget:style(margin: 10px -15px 0 0!important;)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -4,9 +4,9 @@
 ! Collaborators: F4z, xxcriticxx, hawkeye116477, KonoromiHimaries
 ! Homepage: https://www.certyficate.it/
 ! Wsparcie: https://patronite.pl/polskiefiltry
-! Last modified: 25 July 2018
+! Last modified: 26 July 2018
 ! Expires: 2 days
-! Version: 2018072501
+! Version: 2018072601
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -14,7 +14,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018072501 aktualizacja: śr, 25 lipca 2018, 13:32:00
+! v.2018072601 aktualizacja: czw, 26 lipca 2018, 13:18:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -294,6 +294,7 @@ podkarpackahistoria.pl###main-nav1:style(height: 50px !important;)
 portal.abczdrowie.pl##.article__side__stickblock:style(position: absolute!important; left: -3000px!important;)
 portal.abczdrowie.pl##.article__textbox:style(position: absolute!important; left: -3000px!important;)
 prv.pl###prvAliasFrame2:style(height:calc(100vh - 10px)!important;)
+radom24.pl###pojemnik-strony:style(margin-top: 0 !important;)
 spidersweb.pl##.playstation.wall-bg:style(background: none!important)
 tabletowo.pl###main_header:style(margin-top: 0px!important;)
 tv-wschod.pl##.widget:style(margin: 10px -15px 0 0!important;)
@@ -308,20 +309,21 @@ wykop.pl###dyingLinksBox > .dying-links:first-child ~ .dying-links[style="displa
 ~spolka.cda.pl,cda.pl##body:style(background:#121212!important;)
 !
 ! Adblock
-cvninja.pl##script:inject(abort-on-property-write.js, fuckAdBlock)
-dziwnekomiksy.pl##body>*:style(filter: blur(0px) !important;)
+!gadzetomania.pl,wp.pl,autokult.pl,komorkomania.pl##.modal__body-adblock
 alefunny.pl###myModal, .modal-backdrop
 alefunny.pl##.modal-open:style(overflow: auto !important; padding-right: 0px !important;)
-!gadzetomania.pl,wp.pl,autokult.pl,komorkomania.pl##.modal__body-adblock
-fotoblogia.pl,gadzetomania.pl,wp.pl,autokult.pl,komorkomania.pl,medycyna24.pl,smaczneblogi.pl##script:inject(abort-on-property-write.js, __serviceAbModal)
-filmweb.pl##script:inject(abort-on-property-read.js, document.onreadystatechange)
-filmweb.pl##script:inject(setTimeout-defuser.js, notDetected)
-niezalezna.pl##script:inject(noeval.js)
 astroweb.pl##script:inject(abort-on-property-read.js, checkAds)
 aternos.org##script:inject(setTimeout-defuser.js, hasAdblock)
-||wp.hit.gemius.pl/gdejs/xgde.js$script,redirect=noopjs,domain=pilot.wp.pl
+cvninja.pl##script:inject(abort-on-property-write.js, fuckAdBlock)
+dziwnekomiksy.pl##body>*:style(filter: blur(0px) !important;)
+filmweb.pl##script:inject(abort-on-property-read.js, document.onreadystatechange)
+filmweb.pl##script:inject(setTimeout-defuser.js, notDetected)
+fotoblogia.pl,gadzetomania.pl,wp.pl,autokult.pl,komorkomania.pl,medycyna24.pl,smaczneblogi.pl##script:inject(abort-on-property-write.js, __serviceAbModal)
+niezalezna.pl##script:inject(noeval.js)
+pilot.wp.pl##script:inject(set-constant.js, WP.crux.sealed, falseFunc)
 skript.pl##script:inject(abort-current-inline-script.js, $, alert)
 skript.pl##script:inject(abort-current-inline-script.js, document.addEventListener, adblocka)
+||wp.hit.gemius.pl/gdejs/xgde.js$script,redirect=noopjs,domain=pilot.wp.pl
 !
 ! Rules after Adblock
 vod.pl##.infoCloud:style(position: absolute!important; left: -3000px!important;)


### PR DESCRIPTION
<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 

> #8423 + #7533 + brytol.com + niebezpiecznik.pl + trybun.org.pl + allans.pl + proto.pl + filmweb.pl + blogujmy24.pl + socialpress.pl (raporty z Discorda)

A oprócz tego trochę posortowałem i przeniosłem regułę  :style() do odpowiedniego miejsca, gdyż takie reguły robią problemy na ABP :smile:

Zauważyłem, że mamy też problem, choć moze nie taki wielki, ale otóż uBO includuje też listę dla AdGuarda.