### PR TITLE
onet.pl

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -107,6 +107,7 @@ vshare.io###sendif
 !6#-----------------------Privacy filters hide-----------------------!
 !
 !7#-----------------------Privacy filters block-----------------------!
+||sgqcvfjvr.onet.pl
 !
 !8#------------------------General element hiding rules-------------------------!
 24tp.pl,lca.pl,112tychy.pl,30minut.pl,twoje-podhale.pl,upflix.pl,grylogiczne.biz.pl,grydladziewczyn.net.pl##[class*="reklama"]


### PR DESCRIPTION
Skrypty z tej domeny (właściwie jeden, ale z nazwą zmieniającą się co build - wystarczy base64decode zrobić) służą do wysyłania eventów adservera onet.pl/{jakisPrefix}/{base64eventu}.

Proponuję blokować domenę, bo skrypt ładujący się zmienia i ma mimetype document.

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
