### PR TITLE
Udate Advert filters to 2018110201

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -213,6 +213,7 @@ onet.pl##a[href^="http://csr.onet.pl/eclk/clk"]
 ###phContent_avastBadge
 pl##.adbox
 pl##.adsbyg
+pl##.adv_container
 pl##a[href*="://clicks.fortunaaffiliates.com/"]
 pl##a[href*="://converti.se/click/"]
 pl##a[href^="http://s.click.aliexpress.com/"]
@@ -821,7 +822,7 @@ epainfo.pl##DIV.g-single > IMG
 epainfo.pl,vipmultimedia.pl##A.gofollow > IMG
 eparczew.pl###block-block-5
 epiotrkow.pl##a[href^="rd.php"]
-epoznan.pl##[id^="adsys_"]
+epoznan.pl##[id^="adsys_"], [href^="http://epoznan.pl/adsys_"]
 eredivisie.pl##IMG[src^="http://www.goal.pl/ban/"]
 ergokantor.pl###przesuwany_tekst
 erocentrum.pl##.panel

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -9,9 +9,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 30 October 2018
+! Last modified: 2 November 2018
 ! Expires: 1 day
-! Version: 2018103004
+! Version: 2018110201
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2018103004 aktualizacja: wt, 30 pazdziernika 2018, 23:30:00
+! v.2018110201 aktualizacja: pt, 2 listopada 2018, 10:48:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -2052,7 +2052,7 @@ portalsremski.pl##div[class^="ban"]
 portaltatrzanski.com##.promo-baner
 poscigi.pl###rev_slider_1_1_wrapper, .td_block_image_box.td_block_wrap
 posshop.pl###box_custom3
-postawnaswoim.pl,forum.tweaks.pl,androidhacksgames.com,mobilegameshack4u.com,zarabiam.com,solarkurier.pl,miniskrypt.hubaiitv.pl,swirtv.czo.pl,pewnapozyczka.pl,precyl.com,przeklej.org,club4you.pl,darmowetv.pl,forum.vwgolf.pl,szuman.eu,audiostereo.pl,ogloszenia.gazeta.ie,legio24.pl,sdcv.pl,dostawcy-internetu.pl,forum.bukmacherskie.com,nasze.fm,lovekrakow.pl,mh24.pl,faktykonopne.pl,lajfy.com,disco-polo.info,pokemon-go.pl,gazeta-wiesci.pl,polskaniepodlegla.pl,lpg-forum.pl,kuszotv.pl,meczelive.tv,tablety.pl,polskatimes.pl,gazetakrakowska.pl,nacjonalista.pl,ostrowiecnews.pl,medianarodowe.com,prawy.pl,hobby-elektronika.eu,lowiczanin.info##center
+postawnaswoim.pl,forum.tweaks.pl,androidhacksgames.com,mobilegameshack4u.com,solarkurier.pl,miniskrypt.hubaiitv.pl,swirtv.czo.pl,pewnapozyczka.pl,precyl.com,przeklej.org,club4you.pl,darmowetv.pl,forum.vwgolf.pl,szuman.eu,audiostereo.pl,ogloszenia.gazeta.ie,legio24.pl,sdcv.pl,dostawcy-internetu.pl,forum.bukmacherskie.com,nasze.fm,lovekrakow.pl,mh24.pl,faktykonopne.pl,lajfy.com,disco-polo.info,pokemon-go.pl,gazeta-wiesci.pl,polskaniepodlegla.pl,lpg-forum.pl,kuszotv.pl,meczelive.tv,tablety.pl,polskatimes.pl,gazetakrakowska.pl,nacjonalista.pl,ostrowiecnews.pl,medianarodowe.com,prawy.pl,hobby-elektronika.eu,lowiczanin.info##center
 potplayerclub.pl##.potpl-adlabel
 powiatowa.info###jm-header-mod > .jm-module:nth-of-type(2) > .jm-module-in
 powiatowa.info###jm-left > div > .jm-module:nth-of-type(1)
@@ -4149,6 +4149,7 @@ sportowefakty.wp.pl##main div[class*=" "]:empty:not(.btnmute):not(.volsliderbg):
 tv.wp.pl##DIV[style="text-align:center; padding:10px;"]
 tv.wp.pl##SECTION#boksy > DIV > DIV[class]
 tv.wp.pl##SECTION > DIV.wide > DIV + DIV[class]
+tv.wp.pl##[class*="AdvPlaceholderLayout"]
 wiadomosci.wp.pl##DIV[style="position: relative; top: 0px;"] > A[target="_blank"] > DIV
 wiadomosci.wp.pl,gwiazdy.wp.pl,teleshow.wp.pl##A[href*=".wp.pl/"][target="_blank"]:first-child > FIGURE[class^="_"]
 wiadomosci.wp.pl##[target="_blank"] > IMG[src^="https://v.wpimg.pl/"]


### PR DESCRIPTION
Fix #9360, Fix #9363, Fix #9369, Fix #9382


- https://github.com/MajkiIT/polish-ads-filter/issues/9360#issuecomment-434405529
- https://github.com/MajkiIT/polish-ads-filter/issues/9363#issuecomment-434486712

---

- Wycięcie resztki po reklamie wg zaleceń @salionPL i @hawkeye116477.

- Wycięcie filtra, który zaczął wycinać tytuły działów na forum `zarabiam.com`.

- `pl##.adv_container`, narazie na zasięg domen `.pl`.

- `epoznan.pl##[href^="http://epoznan.pl/adsys_"]` podobnie do reguły z wycinaniem elementów po `ID`.


