### PR TITLE
Update advert filters to version 2018113001

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2018113001 aktualizacja: pt, 30 listopada 2018, 08:27:00
+! v.2018113001 aktualizacja: pt, 30 listopada 2018, 08:50:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -1058,12 +1058,9 @@ gizycko.info.pl##body > center:nth-of-type(1) > table > tbody > tr > td:nth-of-t
 glamrap.pl###footmod
 glamrap.pl##[onclick*="Reklama"][target="_blank"] > IMG, #mvp-leader-wrap
 globtroter.pl##a[href^="http://track.omgpl.com/"] > .img-responsive
-glogow-info.pl,glogow.info.pl###leftcol > .module:nth-of-type(n+2):nth-of-type(-n+4)
+glogow-info.pl,glogow.info.pl#?#.contentpaneopen:-abp-contains(Reklama)
+glogow-info.pl,glogow.info.pl#?#.module:-abp-contains(Reklama)
 glogow-info.pl,glogow.info.pl###maincol-broad-800 > center > div:nth-of-type(-n+2)
-glogow-info.pl,glogow.info.pl###rightcol-broad > .module:nth-of-type(1)
-glogow-info.pl,glogow.info.pl###rightcol-broad > .module:nth-of-type(3)
-glogow-info.pl,glogow.info.pl###rightcol-broad > .module:nth-of-type(4)
-glogow-info.pl,glogow.info.pl###rightcol-broad > .module:nth-of-type(5)
 glogow-info.pl,glogow.info.pl##TD[onclick^="window.location.href="], [href^="http://"] > .lazy-loaded
 gazeta-olawa.pl##.absolute, #sidebar-primary-sidebar > div.row
 glokalna.pl###wpbanner-14454

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -9,9 +9,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 29 November 2018
+! Last modified: 30 November 2018
 ! Expires: 1 day
-! Version: 2018112905
+! Version: 2018113001
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2018112905 aktualizacja: czw, 29 listopada 2018, 18:35:00
+! v.2018113001 aktualizacja: pt, 30 listopada 2018, 08:27:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -1744,12 +1744,12 @@ nacjonalista.pl##.napis, .entry-content.entry > A
 nacjonalista.pl##DIV[align="center"]
 nadmorski24.pl##[href^="/dynamicAD/"]
 naekranie.pl##.adform, #attachment_3064862, .screening-banner
-naekranie.pl##.inner-wrap > div[class^=y][style]:not(#drivers-slider):not(#home)
+naekranie.pl##.inner-wrap > div[class^="z"][style]:not(#drivers-slider):not(#home)
 naekranie.pl##.no-review.title-wide > [class^="z"]
-naekranie.pl##.title-wide > div[class^=z][style]
+naekranie.pl##.title-wide > div[class^="z"][style]
 naekranie.pl##div.prawa-szpalta.box > [class^="z"]
 naekranie.pl###home-indexes > div > [class^="z"]
-naekranie.pl##div.icon-star.box > [class^=z]
+naekranie.pl##div.icon-star.box > [class^="z"]
 naekranie.pl##[id^="post-"] > div + div + div > [class^="z"]
 naekranie.pl##div[style="background-color: transparent; margin-top: -61px; min-height: 100%; height: 1200px; "]
 naekranie.pl##div[style^="max-width:"][style$="; margin: auto; "]
@@ -2504,7 +2504,7 @@ tabletowo.pl###menu-item-komputronik, #re_kk_near_logo
 tabletowo.pl##.swckbb, .megatop_wrap, .rd_widget_text
 tabletowo.pl##.widget2:nth-of-type(2)
 tabletowo.pl##.widget2:nth-of-type(3)
-tabletowo.pl##DIV[class*=rek]
+tabletowo.pl##DIV[class*="rek"]
 tabletowo.pl##[id^="text-"]
 tabletowo.pl##[rel="nofollow"][target="_blank"]
 tabletowo.pl##a[href*="dhosting.pl"]
@@ -4257,7 +4257,7 @@ money.pl##div[class]:if(>div[class]:first-child:has-text(REKLAMA):if-not(>*))
 money.pl##DIV.right-column[data-floatingsky] > DIV:first-child
 money.pl##DIV.right-column > [class]:first-child
 money.pl##DIV[style="margin-bottom: 10px"] + DIV > DIV > DIV + DIV + DIV[class]
-money.pl##.cTDBBq, .iUqSbV, .een3d0d111d
+money.pl##.cTDBBq, .iUqSbV, .iin3p0p135d
 money.pl##.main-menu__submenu__offer
 money.pl##.right-column > DIV + DIV[class]
 money.pl##.right-column > DIV > DIV > DIV > DIV + DIV[class]

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 28 November 2018
+! Last modified: 30 November 2018
 ! Expires: 2 days
-! Version: 2018112801
+! Version: 2018113001
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018112801 aktualizacja: sr, 28 listopada 2018, 21:55:00
+! v.2018113001 aktualizacja: pt, 28 listopada 2018, 08:30:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -124,6 +124,7 @@ filmweb.pl###skyBanner
 !
 ! Grupa WP
 ~poczta.wp.pl,wp.pl,~pilot.wp.pl##script:inject(abort-on-property-read.js, WP.inline)
+money.pl###app > div[data-reactroot] > div[class]:matches-css(background-image: /^url\(https:\/\/www\.money\.pl\/static\/bg\.png\)/)
 www.wp.pl##[data-st-area] > div > div > div[class]:matches-css(max-width: 300px):matches-css(max-height: 250px)
 ~www.wp.pl,wp.pl##:xpath(//div[count(*)=3][img[@class][@src]][*[count(*)=1]/*[count(*)=1]/*[count(*)=1]/*[count(*)=1]/*[count(*)=0]])
 www.wp.pl##:xpath(//div[@data-st-area='Zakupy'][count(*)=2][not(header)])


### PR DESCRIPTION
#10401, #10372  - poprawka filtrów 
#9589 - ostatni filtr kosmetyczny dla AdBlock / Adblock Plus i filtr sprawdzający tło dla uBlock Origin / AdGuard.
#10270 - dodanie proponowanych filtrów autora poza sieciowym i kosmetycznym sprawdzającym tło w atrybucie style na razie.

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
