### PR TITLE
Update ABP, uBlock Origin and AdGuard advert filters

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -11,7 +11,7 @@
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
 ! Last modified: 30 November 2018
 ! Expires: 1 day
-! Version: 2018113001
+! Version: 2018113002
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2018113001 aktualizacja: pt, 30 listopada 2018, 08:50:00
+! v.2018113002 aktualizacja: pt, 30 listopada 2018, 12:46:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -1741,13 +1741,13 @@ nacjonalista.pl##.napis, .entry-content.entry > A
 nacjonalista.pl##DIV[align="center"]
 nadmorski24.pl##[href^="/dynamicAD/"]
 naekranie.pl##.adform, #attachment_3064862, .screening-banner
-naekranie.pl##.inner-wrap > div[class^="z"][style]:not(#drivers-slider):not(#home)
-naekranie.pl##.no-review.title-wide > [class^="z"]
-naekranie.pl##.title-wide > div[class^="z"][style]
-naekranie.pl##div.prawa-szpalta.box > [class^="z"]
-naekranie.pl###home-indexes > div > [class^="z"]
-naekranie.pl##div.icon-star.box > [class^="z"]
-naekranie.pl##[id^="post-"] > div + div + div > [class^="z"]
+naekranie.pl##.inner-wrap > div[class^="a"][style]:not(#drivers-slider):not(#home)
+naekranie.pl##.no-review.title-wide > [class^="a"]
+naekranie.pl##.title-wide > div[class^="a"][style]
+naekranie.pl##div.prawa-szpalta.box > [class^="a"]
+naekranie.pl###home-indexes > div > [class^="a"]
+naekranie.pl##div.icon-star.box > [class^="a"]
+naekranie.pl##[id^="post-"] > div + div + div > [class^="a"]
 naekranie.pl##div[style="background-color: transparent; margin-top: -61px; min-height: 100%; height: 1200px; "]
 naekranie.pl##div[style^="max-width:"][style$="; margin: auto; "]
 naekranie.pl##video

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018113002 aktualizacja: ptk, 30 listopada 2018, 10:03:00
+! v.2018113001 aktualizacja: ptk, 30 listopada 2018, 10:04:00
 !
 !
 ! http://alltube.tv/

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 16 Nov 2018
+! Last modified: 30 Nov 2018
 ! Expires: 2 days
-! Version: 2018111603
+! Version: 2018113001
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018116203 aktualizacja: ptk, 16 listopada 2018, 10:23:00
+! v.2018113002 aktualizacja: ptk, 30 listopada 2018, 10:03:00
 !
 !
 ! http://alltube.tv/
@@ -187,6 +187,8 @@ wirtualnygarwolin.pl###sbox-overlay, #sbox-window
 wirtualnygarwolin.pl##body:style(overflow: visible !important;)
 wykop.pl###dyingLinksBox > .dying-links:first-child ~ .dying-links:last-child:style(display:list-item !important)
 wykop.pl###dyingLinksBox > .dying-links:first-child ~ .dying-links[style="display: list-item;"] ~ .dying-links:style(display: none !important)
+w-poblizu.pl###page-wrapper > .page:style(padding: 0 !important;)
+zarabiam.com##body > font[color="green"]:last-of-type:style(color: transparent !important;)
 !
 ! Adblock
 dziwnekomiksy.pl##body>*:style(filter: blur(0px) !important;)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018113002 aktualizacja: pt, 30 listopada 2018, 09:55:00
+! v.2018113002 aktualizacja: ptk, 30 listopada 2018, 10:03:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -418,5 +418,5 @@ ziemiadebicka.pl###header:style(height: 170px !important;)
 ! elka.pl & miedziowe.pl
 elka.pl,miedziowe.pl##:xpath(//*[@align="center"][contains(text(), 'reklama')])
 !
-! filmowakraina.tv#
+! filmowakraina.tv
 filmowakraina.tv##+js(nano-setInterval-booster.js)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -8,7 +8,7 @@
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
 ! Last modified: 30 November 2018
 ! Expires: 2 days
-! Version: 2018113001
+! Version: 2018113002
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018113001 aktualizacja: pt, 28 listopada 2018, 08:30:00
+! v.2018113002 aktualizacja: pt, 30 listopada 2018, 09:55:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -124,7 +124,7 @@ filmweb.pl###skyBanner
 !
 ! Grupa WP
 ~poczta.wp.pl,wp.pl,~pilot.wp.pl##script:inject(abort-on-property-read.js, WP.inline)
-money.pl###app > div[data-reactroot] > div[class]:matches-css(background-image: /^url\(https:\/\/www\.money\.pl\/static\/bg\.png\)/)
+money.pl###app > div[data-reactroot] > div[class]:matches-css(background-image: \/static\/bg\.png/)
 www.wp.pl##[data-st-area] > div > div > div[class]:matches-css(max-width: 300px):matches-css(max-height: 250px)
 ~www.wp.pl,wp.pl##:xpath(//div[count(*)=3][img[@class][@src]][*[count(*)=1]/*[count(*)=1]/*[count(*)=1]/*[count(*)=1]/*[count(*)=0]])
 www.wp.pl##:xpath(//div[@data-st-area='Zakupy'][count(*)=2][not(header)])


### PR DESCRIPTION
#9589 - uBlock Origin nie lubi nawiasów z CSS (lub wymaga w inny sposób zapisu dokładnej `własności` CSS), więc uprościłem sprawdzanie do relatywnej ścieżki.

#10217, #9402  Do filtrów AdGuarda dokleiłem poprawki dla `w-pobliżu` i `zarabiam` (nie trafiają na serwer AdGuarda).

Pod `money.pl` miałbym lekko ulepszony filtr:

```css
!www.money.pl###app > div[data-reactroot] > [class^="sc-"] + div[class*=" "]:not([class^="sc-"]):nth-of-type(6)
```

 ale dałem się wykazać projektowi `Anti-CV` (nie żadne `biodata` / `résumé`), może wmyślą jakieś inne cuda dla Adblock Plus 3.3+.


---

https://github.com/MajkiIT/polish-ads-filter/issues/10401#issuecomment-443179067 - zmieniłem na podstawie obserwacji co zrobili po końcu alfabetu łacińskiego 
<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
