### PR TITLE
Update advert filters

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -11,7 +11,7 @@
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
 ! Last modified: 13 December 2018
 ! Expires: 1 day
-! Version: 2018121303
+! Version: 2018121304
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2018121303 aktualizacja: czw, 13 grudnia 2018, 13:35:00
+! v.2018121304 aktualizacja: czw, 13 grudnia 2018, 17:06:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -1280,7 +1280,7 @@ jablonka.info###gk-newsletter-popup
 jablonka.info###gkMainbodyTop > .box + .box
 jablonka.info###gkSidebar > .nomargin.box
 jablonka.info###gkTop1
-jacus.pl##div.ModulRwdUkryj:nth-of-type(1).
+jacus.pl##div.ModulRwdUkryj:nth-of-type(1)
 jadarhobby.pl##.lf:nth-of-type(5) > table > tbody > tr:nth-of-type(7)
 jagiellonia.net##.prawa:nth-of-type(11) > .naglowek
 jagodnik.pl##.spu-content
@@ -2952,7 +2952,7 @@ wynagrodzenia.pl###slider_kontener
 wyspagier.pl##.adv, .abm_plug
 wyspagier.pl##.banner-static-game
 wyspiarzniebieski.pl##[class^="Comm336"]
-w-poblizu.pl###.da
+w-poblizu.pl##.da
 xboxforum.pl###Notices > .scrollContainer
 xboxforum.pl###content > .pageWidth > .pageContent > .blockContainer:nth-of-type(5) > .noticeContainer
 xfinanse.pl##.entry-image.attachment-post
@@ -3897,7 +3897,6 @@ wawalove.pl##a[href="http://dajsygnal.pl/"]
 wawalove.pl##.floating-ad.advertisement
 wawalove.pl,pytamy.pl,dzieci.pl##[id^="adv"]
 wp.tv##.y9xe8qn
-poczta.wp.pl##body > #page:style(display: block!important;)
 !
 !32#--------------------------WP element block------------!
 ||i.wp.pl/*/stg/wpjslib-nojq.js$script,domain=www.dobreprogramy.pl
@@ -3945,8 +3944,8 @@ www.wp.pl##div > div[class*=" "][height]:not([mode])
 www.wp.pl##aside > div[class*=" "][height]:not([mode])
 www.wp.pl##div[class][data-st-area="kokpitPolecane"]
 www.wp.pl##div[class][data-st-area="Naglowek-duzy"] a[href^="https://radar.wp.pl/"]
-www.wp.pl##div[class*=" "]:-abp-has(> img[src$="/i.wp.pl/a/i/stg/pkf/bg.png"])
-tv.wp.pl##div[class*=" "][height]:has(> img[src^="https://v.wpimg.pl/"][src$="=="]:not([alt]))
+www.wp.pl#?#div[class*=" "]:-abp-has(> img[src$="/i.wp.pl/a/i/stg/pkf/bg.png"])
+tv.wp.pl#?#div[class*=" "][height]:abp-has(> img[src^="https://v.wpimg.pl/"][src$="=="]:not([alt]))
 !
 !34#--------------------------Pudelek/Pudelekx element hide------------!
 pudelek.pl##DIV.cb > DIV[class^="m"]

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 30 Nov 2018
+! Last modified: 13 December 2018
 ! Expires: 2 days
-! Version: 2018113001
+! Version: 2018121301
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018113001 aktualizacja: ptk, 30 listopada 2018, 10:04:00
+! v.2018121301 aktualizacja: czw, 13 grudnia 2018, 17:06:00
 !
 !
 ! http://alltube.tv/
@@ -174,6 +174,7 @@ lubimyczytac.pl###content-container:style(background: none !important; padding-t
 ogrodinfo.pl###header:style(padding-top: 64px !important;)
 onet.pl##.miniSlot:style(min-height: 0rem!important;margin-bottom: 0rem!important;)
 pilkanozna.pl##.index_bg_top:style(top: auto!important;)
+poczta.wp.pl##body > #page:style(display: block !important;)
 podkarpackahistoria.pl###main-nav1:style(height: 50px !important;)
 portal.abczdrowie.pl##.article__side__stickblock:style(position: absolute!important; left: -3000px!important;)
 portal.abczdrowie.pl##.article__textbox:style(position: absolute!important; left: -3000px!important;)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 10 December 2018
+! Last modified: 13 December 2018
 ! Expires: 2 days
-! Version: 2018121001
+! Version: 2018121301
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018121001 aktualizacja: pon, 10 grudnia 2018, 21:45:00
+! v.2018121301 aktualizacja: czw, 13 grudnia 2018, 17:06:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -126,6 +126,7 @@ filmweb.pl##+js(abort-current-inline-script.js, Math.random, adbDetect)
 ! Grupa WP
 ~poczta.wp.pl,wp.pl,~pilot.wp.pl##script:inject(abort-on-property-read.js, WP.inline)
 money.pl###app > div[data-reactroot] > div[class]:matches-css(background-image: /\/static\/bg\.png/)
+poczta.wp.pl##body > #page:style(display: block!important;)
 www.wp.pl##[data-st-area] > div > div > div[class]:matches-css(max-width: 300px):matches-css(max-height: 250px)
 ~www.wp.pl,wp.pl##:xpath(//div[count(*)=3][img[@class][@src]][*[count(*)=1]/*[count(*)=1]/*[count(*)=1]/*[count(*)=1]/*[count(*)=0]])
 www.wp.pl##:xpath(//div[@data-st-area='Zakupy'][count(*)=2][not(header)])


### PR DESCRIPTION
Z dwie literówki z jakąś kropką po zamknięciu nawiasu `).` i `###.`

I mimo wszystko przenoszę CSS, dalej ludzie używają PaleMoon/Watefox/Basilisk i potem będzie płacz że im reklamy wyciekają z AdBlock / Adblock Plus i że muszą wrócić do `EasyList Polish`.



<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
