### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -9,9 +9,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 8 January 2019
+! Last modified: 9 January 2019
 ! Expires: 1 day
-! Version: 2019010801
+! Version: 2019010901
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2019 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2019010801 aktualizacja: wt, 8 stycznia 2019, 08:25:00
+! v.2019010901 aktualizacja: śr, 9 stycznia 2019, 14:21:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -35,7 +35,7 @@
 !1#-----------------------General advert blocking filters-----------------------!
 /*300x300$image,domain=portalgwiazd.pl
 /_adv/*
-/adv/*$image,domain=~arriva.pl|~budus.pl
+/adv/*$image,domain=~arriva.pl|~budus.pl|~filmweb.pl
 /adv/show-windows.php$script,domain=alltube.tv|alltube.pl
 /affiliates/$image,domain=www.pasazer.com
 ##a[href*="techmaniak.pl/www/gact/ckk.php"]
@@ -2135,6 +2135,7 @@ probasket.pl##a[href^="http://bit.ly/"]
 procesor.pl###big-rectangle, .banner_right > [href]
 profeto.pl##.rekl-top
 profil.wp.pl##.bxAdv
+profilki.pl#?#div.centering.tile:-abp-has(.adsbygoogle)
 profilook.pl###ceneo-os783-rZ0og
 programosy.pl##.web.bn-b-0
 progressforpoland.com##.td_block_single_image.wpb_wrapper
@@ -2504,6 +2505,7 @@ system.ekai.pl###banner_reklamowy
 szafa.pl###spol
 szafiarka.pl##.a-info
 szczecinek.com##.gal-wrapper:nth-of-type(15), .reklama-rectangle, .negatyw.row > div.w250:nth-of-type(2), #div.l-row:nth-of-type(17) > .l-box--99.l-box > div
+szczekaopada.pl##.adv750x200
 sztafeta.pl##.mom-e3lanat-wrap
 sztuka-wnetrza.pl##div.adv_w_1
 szukacz.pl###googleContainer
@@ -2634,7 +2636,7 @@ tvmalbork.pl,tvsztum.pl,zulawyimierzeja24.pl,tvregionalna24.pl##.advert_outer
 tvmalbork.pl,tvsztum.pl,zulawyimierzeja24.pl,tvregionalna24.pl##.clickable[onclick^="article_video_advert_click"]
 tvn24.pl###adocean-screening-layer
 tvnwarszawa.tvn24.pl##[id^="TopicItemContainer_"] > .boxItem
-tvp.info##.banner
+tvp.info,legia.net##.banner
 tvpolsat.info##CENTER > A[target="_blank"] > IMG, div.panel-default.panel:nth-of-type(5)
 tv-polska.eu##div.panel-default.panel:nth-of-type(5)
 tvsudecka.pl##.visible-xs


### PR DESCRIPTION
#10980 - można bezpiecznie wyciąć, 
#11004 - brak dowodów, że są inne grafiki reklamowe wycinane tym poprawnie,
#11007 - raczej tylko "marketing" szeptany, nie aż reklama "wewnętrzna"

`profilki.pl#?#div.centering.tile:-abp-has(.adsbygoogle)` - do kompletu filtrów social / cookies:

<ul>

https://github.com/MajkiIT/polish-ads-filter/blob/711ecf69b3c2d45d6306f875a5c7011c5a309596/adblock_social_filters/adblock_social_list.txt#L2106-L2107

https://github.com/MajkiIT/polish-ads-filter/blob/711ecf69b3c2d45d6306f875a5c7011c5a309596/cookies_filters/adblock_cookies.txt#L1240


</ul>

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
