### PR TITLE
Update advert filters

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -9,9 +9,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 12 January 2019
+! Last modified: 13 January 2019
 ! Expires: 1 day
-! Version: 2019011203
+! Version: 2019011301
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -20,7 +20,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2019 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2019011203 aktualizacja: sob, 12 stycznia 2019, 22:45:00
+! v.2019011301 aktualizacja: nie, 13 stycznia 2019, 14:20:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -404,6 +404,7 @@ automatyka.pl###bannerTop, #partnerPresents
 autotrader.pl##.link-search
 b1.pl##.header_spotted, .header_praca, .header_bilety, .header_podreczniki, .header_imprezy, .portal_header
 b24tv.pl##.wpb_content_element.wpb_text_column, #metaslider_4122, #custom_html-4
+badaniaprenatalne.pl##.part-sidebar > .widget:-abp-contains(REKLAMA)
 badaniaprenatalne.pl##.rsb.widget
 bajkitv.pl###watch
 baltic.info.pl##IMG[style="display: block; margin-left: auto; margin-right: auto;"]
@@ -424,6 +425,7 @@ belchatow.bai.pl##.rekls
 benchmark.pl###marketplaceProductBox
 benchmark.pl##.screenContainer
 benchmark.pl##.threeTilesAndLogo.colWide[style="background: #EB6878;"]
+beskidy.news##.c-promo-slide, .o-promo
 besty.pl##SPAN[style=" display: block;margin-bottom: 10px; font-size: 13px;color: #aaa; text-align: center;"]
 besty.pl##[id^="adsense_main_"]
 besty.pl##div:nth-of-type(10) > span
@@ -1158,6 +1160,7 @@ handballnews.pl##p > span > span
 hdtv.com.pl###links
 hdtv.com.pl##[id^="edit"] > table:nth-of-type(n+2)
 hdtv.com.pl##body > center
+hd-opinie.pl###header_banner, #text-5, #better-text-3, #better-text-5, #better-text-6, #better-text-7
 hebe.pl###splash_homepage
 hej.mielec.pl##.divMainBannerShell
 hej.mielec.pl##.noFormat.divOpisCnt >.divKernel > p
@@ -1350,6 +1353,7 @@ kibice.net###dialog
 kibice.net##body > .banner-box
 kiep.pl##div:nth-of-type(12) > .btitemp
 kiep.pl###cright > div:nth-of-type(4)
+kierunekchorwacja.pl##.third-col__advert
 kino-iskra.pl##.box.active > IMG[src^="/img/box/"]
 kinonet.pl##.pl-0.float-xl-right.col-lg-4
 kinonet.pl##a[href^="https://brumflix.com/"]
@@ -1710,6 +1714,7 @@ motobanda.pl##.special-block
 motocaina.pl##.mc-inline-advert > div:nth-of-type(1)
 motocykl-online.pl##.bgWhite.container > .row > .left-rail > .article > .tools > .col-xs-12.ceneo-box-index
 motomi.pl##A > .img-responsive
+motopodhale.info###text-10, #text-11
 motormag.pl##.AdWidget_HTMLWidget
 motormag.pl##.entry-content > div:nth-of-type(1)
 motormag.pl##.entry-content > div:nth-of-type(2)
@@ -2431,13 +2436,13 @@ stooq.com##[id] > b > a[href^="?"]
 stooq.com##a[href^="//stooq.com/ads/f/"]
 stooq.com##div[onclick^="(function"][onclick*="window.open"][style^="animation"]
 stooq.com#?##f13 > table:-abp-has(#f13 > a[href^="//stooq.com/ads/"])
-stooq.com#?##f13 > table:if(#f13 > b:-abp-contains(Artykuł Sponsorowany))
+stooq.com#?##f13 > table:-abp-has(#f13 > b:-abp-contains(Artykuł Sponsorowany))
 stooq.com#?#table:-abp-has(:scope > tbody > tr > td > #aswift_1_expand)
 stooq.pl##[id] > b > a[href^="?"]
 stooq.pl##a[href^="//stooq.pl/ads/f/"]
 stooq.pl##div[onclick^="(function"][onclick*="window.open"][style^="animation"]
 stooq.pl#?##f13 > table:-abp-has(#f13 > a[href^="//stooq.pl/ads/"])
-stooq.pl#?##f13 > table:if(#f13 > b:-abp-contains(Artykuł Sponsorowany))
+stooq.pl#?##f13 > table:-abp-has(#f13 > b:-abp-contains(Artykuł Sponsorowany))
 stooq.pl#?#table:-abp-has(:scope > tbody > tr > td > #aswift_1_expand)
 stooq.pl,stooq.com##:xpath(//*[@align="center"]/*[@id][contains(text(),"REKLAMA")])
 stooq.pl,stooq.com##table[border="0"][cellpadding="0"][cellspacing="0"][align="center"]:not([width])
@@ -2569,6 +2574,7 @@ telewizor.eu###polecamy
 telewizor.eu##img[width="468"][height="60"]
 telewizor.pl###banner_top
 telix.pl##[id^="telix-"]
+telko.in##span[style^="font-size: 0.7em; color: #c8c8c8;"]
 temat.info,bitcoin-online.pl##.bannergroup
 temi.pl##.moduletable:nth-of-type(4)
 tenisklub.pl##DIV[style="width:750px;height:100px;margin:10px auto;"]
@@ -3213,6 +3219,7 @@ zywiecinfo.pl##.promoted
 ||gwiazdybasketu.pl/iframe/$subdocument
 ||haker.com.pl/s*.gif$image
 ||haloursynow.pl/img/banery/
+||hd-opinie.pl/wp-content/themes/hdopinie/images/rightcol_shadow.png$image
 ||hipek.pl/kreacje/$image
 ||hiperogloszenia.pl/sys/ri.gif$image
 ||historia.org.pl/wp-content/uploads/20*/*1680x1050.jpg$image
@@ -4007,7 +4014,6 @@ manager.money.pl##.in > DIV[class]:first-child
 money.pl##A[class][href*=".wp.pl/"] > DIV > IMG[src^="https://v.wpimg.pl/"]
 money.pl##DIV#ADrail > DIV[class]:first-child
 money.pl##DIV#ADrail > DIV > DIV + DIV[class]
-money.pl##div[class]:if(>div[class]:first-child:has-text(REKLAMA):if-not(>*))
 money.pl##DIV.right-column[data-floatingsky] > DIV:first-child
 money.pl##DIV.right-column > [class]:first-child
 money.pl##DIV[style="margin-bottom: 10px"] + DIV > DIV > DIV + DIV + DIV[class]

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 18 December 2018
+! Last modified: 13 January 2029
 ! Expires: 2 days
-! Version: 2018121801
+! Version: 2019011301
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,76 +16,76 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018121801 aktualizacja: wt, 18 grudnia 2018, 21:36:00
+! v.2019011301 aktualizacja: mie, 13 stycznia 2019, 11:51:00
 !
 !
-! http://alltube.tv/
+! alltube.tv
 ! Ominięcie czekania
 alltube.tv###please-wait-container
 alltube.tv#$##iframe-container { display: block !important; }
 !
 !
-! http://www.efilmy.tv/
+! www.efilmy.tv
 ! Ominięcie przycisku "Close Ad and Watch as Free User"
 efilmy.tv###step1
 efilmy.tv###hideOnClick
 efilmy.tv#$##playerVidzer { display: block !important; }
 !
-! http://gahe.pl/
+! gahe.pl
 ! Ominięcie czekania
 gahe.pl###gameloader
 gahe.pl#$##flashgame { visibility: visible; display: block; }
 !
-! http://www.jeja.pl/
+! www.jeja.pl
 ! Ominięcie czekania
 jeja.pl##.gameLoading
 jeja.pl###adLoading
 jeja.pl#$##swf { visibility: visible !important; position: static !important; left: 0px !important; }
 jeja.pl#$##game { visibility: visible !important; position: static !important; left: 0px !important; }
 !
-! http://www.national-geographic.pl/
+! www.national-geographic.pl
 ! Puste miejsce po reklamie
 @@||national-geographic.pl/bundles/burdacore/js/adv.js$script
 national-geographic.pl#$#.advertising-billboard { height: 0px !important; }
 !
-! http://www.vidzer.net/
+! www.vidzer.net
 ! Ominięcie przycisku "Close Ad and Watch as Free User"
 vidzer.net###step1
 vidzer.net###hideOnClick
 vidzer.net#$##playerVidzer { display: block !important; }
 !
-! http://zalukaj.com/
+! zalukaj.com
 ! Ominięcie jednosekundowej reklamy
 zalukaj.com###freePlayerWatch
 zalukaj.com#$##free_player { display: block !important; }
 !
-! http://www.friv12com.com/
+! www.friv12com.com
 ! Ominięcie czekania
 friv12com.com###ava-advert_container
 friv12com.com#$##ava-game_container { display: inherit !important; }
 !
-! http://gry-online.poszkole.pl/
+! gry-online.poszkole.pl
 ! Ominięcie czekania
 gry-online.poszkole.pl###mr-tomato
 gry-online.poszkole.pl#$##fgame { width: 850px !important; height: 600px !important; }
 !
-! http://stooq.pl/
+! stooq.pl
 ! Ukrycie pozostałości po reklamach
 stooq.pl,stooq.com##td[align="center"] > [id]:contains(REKLAMA)
 stooq.pl,stooq.com##table[border="0"][cellpadding="0"][cellspacing="0"]:not([width])[-ext-has='[id="ads_goog_1"]']
 !
-! http://www.cda.pl/
+! www.cda.pl
 ! Ominięcie czekania przy ładowaniu gier
 cda.pl###aa_ad
 cda.pl#$##obiekt { display: block !important; }
 cda.pl#$##kolumnaSrodkowa { height: auto !important; }
 !
-! http://www.komputerswiat.pl
+! www.komputerswiat.pl
 ! Adblock
 komputerswiat.pl#@#.adsbygoogle
 komputerswiat.pl#$#.adsbygoogle { height: 1px !important; }
 !
-! http://www.bankier.pl/
+! www.bankier.pl
 bankier.pl##.boxContent > ul > li[class^="item-"][-ext-has=".premium-link"]
 !
 ! senda.pl
@@ -158,9 +158,13 @@ milionkobiet.pl##.gallery-embed-list-images:style(height: auto !important;)
 ! lowcygier.pl
 lowcygier.pl##body:style(background-image: none !important;)
 !
+! money.pl
+money.pl##div[class]:if(>div[class]:first-child:has-text(REKLAMA):if-not(>*))
+!
 ! style()
 booklips.pl##.js:style(background-image: none !important;)
 cartests.net###td-outer-wrap > .td-header-wrap:style(margin-bottom: 0px!important;)
+chillizet.pl###playerControls .playIcon:style(opacity: 1 !important;)
 chojnow.pl##div#top:style(height: 37px!important;)
 ciekawostkihistoryczne.pl##.page:style(background: #dbdbdb !important;)
 eku24.net##.paralax-image:style(height: 100px !important;)
@@ -172,6 +176,7 @@ onet.pl##.miniSlot:style(min-height: 0rem!important;margin-bottom: 0rem!importan
 pilkanozna.pl##.index_bg_top:style(top: auto!important;)
 poczta.o2.pl,poczta.wp.pl#$#body > #page { display: block!important; }
 podkarpackahistoria.pl###main-nav1:style(height: 50px !important;)
+pogonsportnet.pl##.kode-header-absolute:style(top: 0 !important;)
 portal.abczdrowie.pl##.article__side__stickblock:style(position: absolute!important; left: -3000px!important;)
 portal.abczdrowie.pl##.article__textbox:style(position: absolute!important; left: -3000px!important;)
 radom24.pl###pojemnik-strony:style(margin-top: 0 !important;)
@@ -212,11 +217,3 @@ komputerswiat.pl###googleAdsCont:style(position: absolute !important; left: -300
 !#if (adguard_ext_firefox)
 polygamia.pl$$.screening
 !#endif
-!
-!
-! Eurozet
-chillizet.pl###playerControls .playIcon:style(opacity: 1 !important;)
-!
-!
-! pogonsportnet.pl
-pogonsportnet.pl##.kode-header-absolute:style(top: 0 !important;)

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2019011301 aktualizacja: mie, 13 stycznia 2019, 11:51:00
+! v.2019011301 aktualizacja: nie, 13 stycznia 2019, 11:51:00
 !
 !
 ! alltube.tv

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 27 December 2018
+! Last modified: 13 January 2019
 ! Expires: 2 days
-! Version: 2018122703
+! Version: 2019011301
 ! Support:
 !   Email >> errors@certyficate.it
 !   Discord >> http://ds.certyficate.it
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 Certyficate IT
 ! Najnowsza wersja zawsze na:  https://www.certyficate.it/adblock/
-! v.2018122703 aktualizacja: czw, 27 grudnia 2018, 12:25:00
+! v.2019011301 aktualizacja: nie, 13 stycznia, 14:22:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -125,6 +125,7 @@ filmweb.pl##+js(abort-current-inline-script.js, Math.random, adbDetect)
 !
 ! Grupa WP
 ~poczta.wp.pl,wp.pl,~pilot.wp.pl##+js(abort-on-property-read.js, WP.inline)
+money.pl##div[class]:if(>div[class]:first-child:has-text(REKLAMA):if-not(>*))
 money.pl###app > div[data-reactroot] > div[class]:matches-css(background-image: /\/static\/bg\.png/)
 poczta.wp.pl##body > #page:style(display: block !important;)
 www.wp.pl##[data-st-area] > div > div > div[class]:matches-css(max-width: 300px):matches-css(max-height: 250px)


### PR DESCRIPTION
* #11021, #11073, #11049, #11022 - wycięcie resztek po reklamie / reklam

* #11122 - bez namierzenia jaka zewnętrzna lista wycięła zdjęcie i połowę artykułu

* `money.pl##div[class]:if(>div[class]:first-child:has-text(REKLAMA):if-not(>*))` - przenoszę na listę filtrów ubo/adguard, fałszywy alarm z bardzo mocnym wyłączeniem `if-not` i `if`

* #11128 - dwie reklamy w prawej kolumnie, bez "POLECAMY".

* #11110  - wycięcie reklamy i reklamowych belek, cień wycinam też, bo brzydko wygląda jak usunę same puste pola

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
