### PR TITLE
Add polish resources for uBO/NA

### DIFF
--- a/polish-adblock-filters/polish_uBO_resources.txt
+++ b/polish-adblock-filters/polish_uBO_resources.txt
@@ -1,0 +1,13 @@
+# Expires: 1 day
+
+wpAdsRemover.js application/javascript
+(function() {
+      Object.defineProperty(Object.prototype, 'bodies', {
+        get: function get() {
+          return function () {};
+        },
+        set: function set() {
+          return function () {};
+        }
+      });
+})();


### PR DESCRIPTION
<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
Można używać zamiast skryptu w parze z regułą: `wp.pl##+js(wpAdsRemover.js)` (brakujące domeny dopisać) :smile:.
Trzeba tylko dopisać adres tego do zaawansowanych ustawień uBO do `userResourcesLocation` zamiast `none`. Taka alternatywa jakby ktoś nie polubił GM/TM/VM.