### PR TITLE
fix: #14728 usunięcie filtra stepstone.pl

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -3594,7 +3594,6 @@ zywiecinfo.pl##.promoted
 ||static.wizaz.pl/system/kwc/promo/kwc_promo_box_*.html$subdocument
 ||statics.d404.pl/bundles/spoonsite/$image,domain=~motocaina.pl
 ||statics.tarsago.pl/$object-subrequest,domain=meczelive.tv|mecze24.pl
-||stepstone.pl^
 ||stg.wp.pl^$subdocument
 ||studentnews.pl/img/ban/b*.jpg$image
 ||superfilm.pl/*source=admedia&model=pop$popup

--- a/polish-pihole-filters/all_ads_filters.txt
+++ b/polish-pihole-filters/all_ads_filters.txt
@@ -133458,7 +133458,6 @@
 0.0.0.0 sitebravefull.info
 0.0.0.0 smart.idmnet.pl
 0.0.0.0 sooloaph.com
-0.0.0.0 stepstone.pl
 0.0.0.0 track.cux.io
 0.0.0.0 v.wpimg.pl
 0.0.0.0 vaks.pl

--- a/polish-pihole-filters/hostfile.txt
+++ b/polish-pihole-filters/hostfile.txt
@@ -3187,7 +3187,6 @@
 0.0.0.0 smart.idmnet.pl
 0.0.0.0 smartadserver.com
 0.0.0.0 sooloaph.com
-0.0.0.0 stepstone.pl
 0.0.0.0 stg.wp.pl
 0.0.0.0 thiksikr.com
 0.0.0.0 track.cux.io


### PR DESCRIPTION
Filtr uniemożliwia normalne korzystanie ze strony, na przykład zmianę języka, przejście do zapisanych ofert, zamknięcie cookie bar.
fix: https://github.com/MajkiIT/polish-ads-filter/issues/14728