### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -11,7 +11,7 @@
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
 ! Last modified: 16 December 2019
 ! Expires: 1 day
-! Version: 2019121601
+! Version: 2019121602
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -19,7 +19,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2019 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2019121601 aktualizacja: pon, 16 grudnia 2019, 16:25:00
+! v.2019121602 aktualizacja: pon, 16 grudnia 2019, 22:52:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -3858,6 +3858,7 @@ zywiecinfo.pl##.promoted
 @@|http://w.iplsc.com/internal/inpl.intad/$script,domain=interia.pl
 @@||*cda.pl/*advertise.js$script,domain=cda.pl
 @@||adocean.pl/files/js/ado.js|$domain=filmweb.pl
+@@||adserver.kresy.pl/www/delivery/*.php$script,domain=kresy.pl
 @@||adtaily.pl/wp-content/themes/adtaily_*/$domain=www.adtaily.pl
 @@||adwords.radom.pl^
 @@||angielskie-slowka.pl/speecher/advert/*.mp3

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,16 +6,16 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 4 December 2019
+! Last modified: 16 December 2019
 ! Expires: 1 day
-! Version: 2019120401
+! Version: 2019121601
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2019 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2019120401 aktualizacja: sr, 4 grudnia 2019, 22:00:00
+! v.2019121601 aktualizacja: pn, 16 grudnia 2019, 22:44:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -442,8 +442,8 @@ cda-tv.pl##+js(nano-setTimeout-booster.js, TheLink)
 brodnica-cbr.pl,ciechanowinaczej.pl,ddb24.pl,e-wyszogrod.pl,egarwolin.pl,egorzow.pl,golub-cgd.pl,ibialoleka.pl,ibielsk.pl,ikampinos.pl,imokotow.pl,infosiedlce.pl,iotwock.info,ipragapoludnie.pl,itvpiaseczno.pl,izoliborz.pl,kurierpodlaski.pl,lipno-cli.pl,lowicz24.eu,nolesnica.pl,ototorun.pl,rypin-cry.pl,szczecinek.com,twojradom.pl,wabrzezno-cwa.pl,wio.waw.pl,zambrow.org,zycie.pila.pl##.c-content__adv:style(padding-top: 0 !important;)
 !
 ! Polsat
-www.polsatnews.pl,www.polsatsport.pl##.ads .videoPlayer__vast, .ads .videoPlayer__mask[data-time]
-||redirector.redefine.pl/r/*$media,redirect=noop-1s.mp4,domain=www.polsatnews.pl|www.polsatsport.pl
+polsatnews.pl,polsatsport.pl##.ads .videoPlayer__vast, .ads .videoPlayer__mask[data-time]
+||redirector.redefine.pl/r/*$media,redirect=noop-1s.mp4,domain=polsatnews.pl|polsatsport.pl
 !
 ! it-manuals.info
 it-manuals.info###pum-822


### PR DESCRIPTION
* #15347 (i można usunąć etykietę błąd)
* #15337 - usuwamy reklamę na subdomenach np. `https://interwencja.polsatnews.pl`.

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
