### PR TITLE
Update to version 2020032801

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -9,9 +9,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 26 March 2020
+! Last modified: 28 March 2020
 ! Expires: 1 day
-! Version: 2020032601
+! Version: 2020032801
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -19,7 +19,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2020 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2020032601 aktualizacja: czw, 26 marca 2020, 11:30:00
+! v.2020032801 aktualizacja: sob., 28 marca 2020, 14:00:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -4556,7 +4556,6 @@ zwiedzamyparyz.pl###text-6, .a-single, .gyg-widget
 ||vaks.pl^
 ||vidoza*.github.io/*/*.wasm
 ||mg.steepto.com^
-||cackle.me^
 ||signal.netu.tv$websocket
 !
 !40#--------------------------Bitcoin whitelist ------------!


### PR DESCRIPTION
Proponuję usunięcie reguły `||cackle.me^`, ponieważ na niektórych stronach, na przykład tutaj - `https://click-storm.com/en/articles/29051/` blokuje widget z komentarzami.


<details><summary>Obrazek</summary>

![image](https://user-images.githubusercontent.com/11742596/77823624-d5d81880-70fc-11ea-8b6e-a927e811526d.png)

</details>