### PR TITLE
airly.eu

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -378,7 +378,7 @@ apynews.pl##.featured-advert
 archiwum.wiesci.com.pl##table:nth-of-type(1) > tbody > tr > td:nth-of-type(3), table:nth-of-type(2) > tbody > tr > td:nth-of-type(3)
 arenadesign.pl##div.owl-item
 arka.tv###m > A > IMG
-airly.eu##.widget-block
+airly.eu##.ads-wrapper
 asta24.pl###hero2
 astar.czest.pl###astar
 astratex.pl##[class^="bFix"]
@@ -3442,7 +3442,6 @@ zywiecinfo.pl##.promoted
 ||api.ergokantor.pl/widgets/$subdocument
 ||api.systempartnerski.pl^$domain=niepoddawajsie.pl
 ||aptekacentrum.lublin.pl/images/*1920x1080.jpg$image
-||airly.eu/map/static/media/banner-pl.*.png$image
 ||arpass.nazwa.pl/pliki/swf/$image
 ||atrexpress.com.pl/fileadmin/user_upload/grafika/baner$image
 ||autotrader.pl/Resources/Images/credit-agricole/$image

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -378,7 +378,6 @@ apynews.pl##.featured-advert
 archiwum.wiesci.com.pl##table:nth-of-type(1) > tbody > tr > td:nth-of-type(3), table:nth-of-type(2) > tbody > tr > td:nth-of-type(3)
 arenadesign.pl##div.owl-item
 arka.tv###m > A > IMG
-airly.eu##.ads-wrapper
 asta24.pl###hero2
 astar.czest.pl###astar
 astratex.pl##[class^="bFix"]


### PR DESCRIPTION
`https://airly.eu/map/pl/`

Cześć społeczności AdBlockowiczów!

Nazywam się Dariusz Czajkowski i jestem pracownikiem firmy [Airly](airly.eu). Kilka tygodni temu na naszej stronie przestały działać niektóre elementy, jak slider do sprawdzania historycznych pomiarów. Zauważyliśmy, że funkcjonalność przestała działać gdy włączonego mamy uBlocka/AdBlocka i dosyć szybko znaleźliśmy, że filtr zdefiniowany [tutaj](https://github.com/MajkiIT/polish-ads-filter/blob/master/polish-adblock-filters/adblock.txt#L381) blokuje niektóre elementy niebędące reklamami.

<img width="1510" alt="Screen Shot 2020-04-16 at 7 10 42 PM" src="https://user-images.githubusercontent.com/4501047/79485753-09c89e80-8016-11ea-99a6-d495e148718d.png">

W związku z tym za kilka dni będziemy wypuszczali nową wersję. Dla Waszej i naszej wygody, wszystkie reklamy będziemy umieszczali w elementach z klasą `ads-wrapper`, a `widget-block` zmienimy na `card`, żeby nie czekać, aż wtyczki zaciągną nową wersję filtra.

Usuwam również `airly.eu/map/static/media/banner-pl.*.png$image`, bo przestaliśmy go używać jakiś czas temu.

O wypuszczeniu nowej wersji na produkcję poinformuję Was niezwłocznie komentarzem pod tym Pull Requestem.

Miłego blokowania ;)