### PR TITLE
Added ad/tracking domains detected on tvn24.pl

### DIFF
--- a/polish-pihole-filters/hostfile.txt
+++ b/polish-pihole-filters/hostfile.txt
@@ -246,6 +246,12 @@
 # [o2.pl]
 0.0.0.0 adfiles.o2.pl.sds.o2.pl
 #
+# [tvn24.pl]
+0.0.0.0 socialmedia-statistics.tvn24.pl
+0.0.0.0 ads.2win.pl
+0.0.0.0 loteria.pocketads.pl
+0.0.0.0 beta.pocketads.pl
+#
 # [stat.pl]
 0.0.0.0 s1.hit.stat.pl
 0.0.0.0 s2.hit.stat.pl


### PR DESCRIPTION
Four new ad/tracking domains encountered while browsing tvn24.pl
Blocker: Pi-hole 5.0
