### PR TITLE
Add issue labeler bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/z_other_matters.md
+++ b/.github/ISSUE_TEMPLATE/z_other_matters.md
@@ -9,6 +9,24 @@ Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTI
 Thanks for reporting to Polish Filters for AdBlock, uBlock and AdGuard.
 -->
 
+<!--
+Co mamy schować, zablokować albo w czym jest problem, może pojawił się jakiś błąd?
+Proszę wstawić x pomiędzy znakami [] obok typu/typów, którego/których to zgłoszenie dotyczy.
+W przypadku pomyłki co do typu, proszę odznaczyć checkbox (przycisk wyboru) lub usunąć x i zamiast niego - wstawić spację.
+What should we hide, block or what is the problem, maybe there is an error?
+Please put an x between the [] signs next to the type(s) for which this issue relates.
+In case of a mistake as to the type, please uncheck the checkbox or delete x and insert a space instead.
+-->
+### Typ elementu/problemu <!--Item / problem type-->
+- [] Reklama <!--Advert-->
+- [] Wydobywanie kryptowalut <!--Cryptocurrency mining-->
+- [] Anty-adblock <!--Anti-adblock wall-->
+- [] Komunikat dot. ciasteczek i polityki prywatności/RODO <!--Message about cookies and GDPR/privacy policy-->
+- [] Element społecznościowy <!--Social network element-->
+- [] Pi-hole, hosts i spółka <!--Pi-hole, hosts & co-->
+- [] Błąd <!--Bug, mistake, no-no-->
+- [] Pytanie <!--Question-->
+
 ### Zrzut ekranu <!--Screenshot-->
 <!--
 Przeciągnij i upuść tutaj swój zrzut lub zamieść do niego link.

--- a/.github/probot.js
+++ b/.github/probot.js
@@ -1,8 +1,0 @@
-on('issues.opened')
-  .comment(`
-    Hello @{{ sender.login }}. Thanks for inviting me to your project.
-    Read more about [all the things I can help you with][config]. I can't
-    wait to get started!
-
-    [config]: https://github.com/bkeepers/workflow/blob/master/docs/configuration.md
-  `);

--- a/.github/workflows/issueLabel.yml
+++ b/.github/workflows/issueLabel.yml
@@ -1,0 +1,76 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            var body = context.payload.issue.body;
+            var labels = context.payload.issue.labels;
+            var labelSet = [
+              {
+                "body": "Anty-adblock",
+                "label": "adblock detect",
+              },
+              {
+                "body": "Reklama",
+                "label": "reklama",
+              },
+              {
+                "body": "Wydobywanie kryptowalut",
+                "label": "kryptokoparki",
+              },
+              {
+                "body": "Komunikat dot. ciasteczek i polityki prywatności\/RODO",
+                "label": "cookies",
+              },
+              {
+                "body": "Element społecznościowy",
+                "label": "social filters",
+              },
+              {
+                "body": "Pi-hole, hosts i spółka",
+                "label": "hosts file",
+              },
+              {
+                "body": "Błąd",
+                "label": "błąd",
+              },
+              {
+                "body": "Pytanie",
+                "label": "pytanie",
+              },
+            ]
+
+            var labelsToAdd = [];
+
+            for (const i in labelSet) {
+              var re_add = new RegExp("- \\[[xX]] "+labelSet[i].body);
+              var re_remove = new RegExp("- \\[[ ]] "+labelSet[i].body);
+              if(body.match(re_add) && !labels.some(e => e.name === labelSet[i].label)) {
+                labelsToAdd.push(labelSet[i].label);
+              }
+              if(body.match(re_remove) && labels.some(e => e.name === labelSet[i].label)) {
+                github.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: labelSet[i].label
+                })
+              }
+            }
+
+            if (labelsToAdd.length > 0) {
+              github.issues.addLabels({
+                      issue_number: context.issue.number,
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      labels: labelsToAdd
+              })
+            }


### PR DESCRIPTION
Jako że poprzedni bot (https://github.com/MajkiIT/polish-ads-filter/pull/17219) nie działał do końca tak jak chcieliśmy, to znalazłem akcję `actions/github-script`, która jest podobna do apki Workflow, której używamy w PFT i zrobiłem skrypt z jej wykorzystaniem.
Jeżeli kratka jest pusta, to etykieta jest usuwana, a jeśli jest X to jest dodawana.
Tablica obiektów `labelSet` zawiera reguły, body to wpis w zgłoszeniu (regex).