### PR TITLE
Aktualizacja bota przydzielającego etykiety

### DIFF
--- a/.github/workflows/issueLabel.yml
+++ b/.github/workflows/issueLabel.yml
@@ -15,7 +15,7 @@ jobs:
             var labels = context.payload.issue.labels;
             var labelSet = [
               {
-                "body": "Anty-adblock",
+                "body": "(Anty-adblock|adblock)",
                 "label": "adblock detect",
               },
               {
@@ -27,11 +27,11 @@ jobs:
                 "label": "kryptokoparki",
               },
               {
-                "body": "Komunikat dot. ciasteczek i polityki prywatności\/RODO",
+                "body": "(Komunikat dot. ciasteczek i polityki prywatności\/RODO|ciasteczka|rodo)",
                 "label": "cookies",
               },
               {
-                "body": "Element społecznościowy",
+                "body": "(Element społecznościowy|social)",
                 "label": "social filters",
               },
               {
@@ -51,9 +51,13 @@ jobs:
             var labelsToAdd = [];
 
             for (const i in labelSet) {
-              var re_add = new RegExp("- \\[[xX]] "+labelSet[i].body);
-              var re_remove = new RegExp("- \\[[ ]] "+labelSet[i].body);
+              var re_add = new RegExp("- \\[[xX]] "+labelSet[i].body, "i");
+              var re_remove = new RegExp("- \\[[ ]] "+labelSet[i].body, "i");
+              var re_add_fire = new RegExp("Kategoria: "+labelSet[i].body, "i");
               if(body.match(re_add) && !labels.some(e => e.name === labelSet[i].label)) {
+                labelsToAdd.push(labelSet[i].label);
+              }
+              if(body.match(re_add_fire) && !labels.some(e => e.name === labelSet[i].label)) {
                 labelsToAdd.push(labelSet[i].label);
               }
               if(body.match(re_remove) && labels.some(e => e.name === labelSet[i].label)) {


### PR DESCRIPTION
<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 

Z racji tego, że @MajkiIT nie zmienił kodu formularza na stronie, to dodałem kolejny regex => `Kategoria: nazwa`. To zadziała tylko na jedną etykietę, jeżeli kolejne są po przecinku to albo trzeba byłoby jakoś poprawić ten kod po stronie bota etykietującego (więcej roboty, pewnie trzeba by każdą możliwość sprawdzać) albo w formularzu, zrobić by w oddzielnych liniach fire-bot wpisywał każdą kategorię np. `- [X] Anty-adblock`, a w kolejnej kolejną kategorię, tak by było najlepiej (choć jakoś póki co nigdy nie widziałem, by ktoś zaznaczał 2 lub więcej kategorii w tym formularzu na certyficate.it) :smile:.

