### PR TITLE
fix do anty-adblocka na ewybory.eu

### DIFF
--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -572,3 +572,10 @@ napiprojekt.pl##+js(insert-iframe, 1, honeypot, https://www.napiprojekt.pl/napis
 ppe.pl###hot-slides-wrapper #hot_0, #hot-slider #m_hot_0
 ppe.pl##+js(ac, active, #m_hot_1)
 ppe.pl##+js(ac, box_active, #hot_1)
+!
+! ewybory.eu
+ewybory.eu###ybfoexqv-blanket
+ewybory.eu###ybfoexqv-blanket button
+ewybory.eu###ybfoexqv-blanket>div
+ewybory.eu###ybfoexqv-blanket>div>div
+ewybory.eu##body:style(overflow: auto !important;)


### PR DESCRIPTION
fix do anty-adblocka na ewybory.eu i ominięcie blokady scrolla

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
