### PR TITLE
Update stale action to latest version

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write  # for actions/stale to close stale issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           stale-issue-message: '@MajkiIT To zgłoszenie zostało oznaczone jako nieaktualne, ponieważ nie było żadnej aktywności przez 60 dni. Usuń etykietę lub napisz komentarz, bo w przeciwnym wypadku zostanie ono zamknięte w ciągu 14 dni.'
           stale-issue-label: 'odrzucone'


### PR DESCRIPTION
<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
Obecnie GH Actions zamyka zgłoszenia i błędnie oznacza jako ukończone, choć etykieta wskazuje inaczej. W najnowszej wersji już to naprawili i teraz jest domyślnie jako nie planowane. Oprócz tego jakieś inne błędy też naprawili.