### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 21 November 2022
+! Last modified: 25 November 2022
 ! Expires: 1 day
-! Version: 2022112102
+! Version: 2022112500
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2022 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2022112102 aktualizacja: pon, 21 listopada 2022, 08:30:00
+! v.2022112500 aktualizacja: pią, 25 listopada 2022, 23:20:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -2075,6 +2075,7 @@ meczyki.net.pl##.subtext > A > IMG
 meczyki.net.pl##[class^="cool-stuff"]
 meczyki.pl##.bookie-ranks, .container-communique, .placeholder.margin.banner, .simple-link
 meczyki.pl##.container-banner-top.container-banner
+meczyki.pl##.footer ~ .popup
 mediacv.pl##.baner-1
 mediacv.pl##[class^="ban-"]
 mediaexpert.pl##.js-promoClick
@@ -5253,6 +5254,7 @@ blogujmy24.pl##.blogu-widget, .blogu-text, #custom_html-3
 blogujmy24.pl,tarnow.in,ps4site.pl,bebetalent.pl,gorliceiokolice.eu,naszabramow.pl###text-3
 bstok.pl##.vc_box_border_grey.vc_single_image-wrapper, .ntphubdx-type-image.ntphubdx-container, .ntphubdx-image
 businesstraveller.pl##.widget-clear.widget
+ceo.com.pl##a[rel="sponsored"]
 chelmno.com.pl###text-19
 codojedzenia.pl###text-44
 craftportal.pl###text-13

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 08 November 2022
+! Last modified: 25 November 2022
 ! Expires: 1 day
-! Version: 2022110800
+! Version: 2022112500
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2022 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2022110800 aktualizacja: wt, 08 listopada 2022, 22:51:00
+! v.2022112500 aktualizacja: pią, 25 listopada 2022, 22:41:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -572,6 +572,9 @@ tekstowo.pl#@##advSong
 tekstowo.pl#$##advSong { visibility: hidden !important }
 tekstowo.pl#@#[class^="adv-"]
 tekstowo.pl#$#.teledysk { flex: 0 0 100% !important; max-width: 100% !important; }
+!
+! meczyki.pl
+meczyki.pl##:not(.onnetwork-banner) > .placeholder:not(.onnetwork-banner):style(height: 0 !important; min-height: 0 !important;)
 !
 ! uBlock-user
 napiprojekt.pl##+js(insert-iframe, 1, honeypot, https://www.napiprojekt.pl/napisy-42731-Ostatni-U-Boot-(1993), width: 1px !important; height: 1px !important; position: absolute !important; left: -3000px !important)


### PR DESCRIPTION
fix https://github.com/FiltersHeroes/PolishAnnoyanceFilters/issues/3023 / fix https://github.com/AdguardTeam/AdguardFilters/issues/135556

Pop-up przekierowuje do efortuny czyli nie jest to self-promo, aż ktoś nie udowodni, że zarząd efortuny prowadzi markę meczyki.

Możliwe, że emisja jest ustawiona do godziny 16 dzień przed polskim meczem.

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 


---

fix #21358 
