### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2023 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2023020600 aktualizacja: wto, 14 lutego 2023, 22:46:00
+! v.2023021400 aktualizacja: wto, 14 lutego 2023, 22:46:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 6 February 2023
+! Last modified: 14 February 2023
 ! Expires: 1 day
-! Version: 2023020601
+! Version: 2023021400
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2023 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2023020601 aktualizacja: pon, 6 lutego 2023, 12:05:00
+! v.2023020600 aktualizacja: wto, 14 lutego 2023, 22:46:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -3169,6 +3169,7 @@ spidersweb.pl##section.show-for-medium.margin-bottom35.padding-35-0.greybg > .ro
 spidersweb.pl#?#.sidebar-panel:-abp-has(center:only-child script:-abp-contains(googletag.cmd.push))
 spidersweb.pl##script[src*="optad360.io"] ~ div > div[id][class=" "]
 spidersweb.pl##[id^="SonyPs5Ad"], .app-adBox
+spidersweb.pl##.newAd
 spiswitryn.pl##[src^="https://www.slubi.pro/banery/"]
 spiswitryn.pl##h3:nth-of-type(3)
 spiz.pl,roksa.pl##.c
@@ -3776,6 +3777,7 @@ www.axn.pl###block-dart-dart-tag-980x100-ldr-top.block.block-dart > .content > .
 www.bankier.pl#?#li.m-home-link-list__item:-abp-contains(/reklama/)
 www.bankier.pl##.o-home-ecom-box
 www.benchmark.pl##.product
+www.benchmark.pl##.market
 www.biala24.pl##[id^="cbox"]
 www.bolec.info##.baner_max, div.bottom > .top_menu
 www.bolec.info##.center-cropped[style^="background-color:"]
@@ -4744,7 +4746,6 @@ zywiecinfo.pl##.promoted
 @@||sascdn.com/diff/video$domain=wymarzonyogrod.pl
 @@||sascdn.com/video/flowplayer-plugin.swf$object,domain=wymarzonyogrod.pl
 @@||sascdn.com^$object-subrequest,script,domain=poradnikzdrowie.pl|www4.rp.pl|eskago.pl
-@@||sgqcvfjvr.onet.pl^$script,domain=www.komputerswiat.pl|wiadomosci.onet.pl|facet.onet.pl|kultura.onet.pl|sport.onet.pl|podroze.onet.pl|plejada.pl|pulsembed.eu|vod.pl|auto-swiat.pl
 @@||smartadserver.com^$script,domain=poradnikzdrowie.pl|www4.rp.pl|fotka.pl
 @@||ssl.allegro.pl/order/^
 @@||staticpics2.allegrostatic.pl/adverts/otomoto_pl/*128x96$image,domain=allegro.pl


### PR DESCRIPTION
Resztki po reklamach, blok reklamowy jaki WP nie zmieniło na chroniony losowymi klasami i usunięcie filtra bo EasyPrivacy usunęło blokadę jako tracker (wygrała użyteczność portalu).

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
