### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -1883,6 +1883,7 @@ konflikty.pl##.vwpc-section-custom_content
 konin24.info##.flex-list, [href^="Plugin/ads_click.php"]
 konin24.info###popup_box
 konindzieciom.pl##.re_div_show
+kontomaniak.pl##.banner-image
 kopalniawiedzy.pl##.right-col-sky
 kopalniawiedzy.pl##.ui-helper-clearfix.box.interview > .ui-helper-clearfix
 korkosfera.pl##div#copyright_ne
@@ -3345,8 +3346,8 @@ spottedlublin.pl##[role="main"] > .row, #advices-stream
 spottedskarzysko.pl##p[align="center"] > a[target="_blank"][rel="noopener noreferrer"] > img
 spottedskarzysko.pl##p[style="text-align: center;"] > a[rel="noopener noreferrer"] > img
 spryciarze.pl###banner_konkursowy
-sprzedajemy.pl###mon-AListTop, .vivusSidebar
-sprzedajemy.pl###mon-AdsAdsDetailsTop
+sprzedajemy.pl##.vivusSidebar, .desktopLayTopPremiumWrp, .desktopLayTopPremium, .top-banner-not-fixed, .ads_configuration
+sprzedajemy.pl###mon-AdsAdsDetailsTop, #mon-AListTop
 sprzedajsuknie.pl##.adsblock1
 stadiony.net##div > A > IMG
 stalenierdzewne.pl##.col-banners-article

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 13 January 2024
+! Last modified: 14 January 2024
 ! Expires: 1 day
-! Version: 2024011301
+! Version: 2024011401
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2023 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024011201 aktualizacja: sob, 13 stycznia 2024, 18:35:00
+! v.2024011401 aktualizacja: nie, 14 stycznia 2024, 14:44:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -649,7 +649,7 @@ bukowskilider.pl##.wp-image-218.size-full.alignnone
 bukowskilider.pl##.wp-image-9190.alignnone
 bukowskilider.pl##.wp-image-9393.alignnone
 busko.com.pl##section#reklama-box
-businessinsider.com.pl###adSS-Detal, .post-container, .bottom-share-module, .clearfix, .adBoxTop, #main > .sH_bottom_first, .adSlotWidget, .adsContainer
+businessinsider.com.pl###adSS-Detal, .post-container, .bottom-share-module, .clearfix, .adBoxTop, #main > .sH_bottom_first, .adSlotWidget, .adsContainer, .newsletterHeader
 businessinsider.com.pl##[class*="placeholder"][data-configuration*="slotName"][data-run-module$="Ad"]
 businessjournal.pl##.add
 businessjournal.pl##A[href^="http://"] > [class*="wp-image-"][width="750"]
@@ -703,7 +703,6 @@ chamskie.pl###ad-bg-transparent
 chamsko.pl##.main-banner
 chamsko.pl##[href^="http://empire.goodgamestudios.com/"]
 charaktery.eu##.text.custom_popup.popup.window_popup, .promo_box
-czateria.interia.pl###IPLAbanner
 chelmno.com.pl##body > p:nth-of-type(1)
 chelmski.eu##[class^="ad-single"], [class^="ad-home"], .reklamacenter
 chilitonka.com##.wpcnt-header
@@ -808,7 +807,7 @@ czajna.pl##article.contain_im_grid.inf_scr_item.small_post.repick_item:nth-of-ty
 czasciechanowa.pl##.et_pb_row_22.et_pb_row, .et_pb_row_0.et_pb_row, .n2-ow
 czasdzieci.pl##.adlabel, .banSetBox, .a_dslot
 czaskultury.pl#?#div.row > .col-md-12 > .line-header > span:-abp-contains(Reklama)
-czateria.interia.pl##.video-player-container
+czateria.interia.pl##.video-player-container, #IPLAbanner
 czechowice.biz,pszczyna.biz,tychy.info##.blok-r, .blok-billboard
 czecho.pl##header.blok-extended.small.pasek-red, #footer.blok-extended.serwis.small.pasek-red
 czerwona-skarbonka.pl##div.wp-block-image
@@ -1200,7 +1199,7 @@ filesdark.com##.btopnews.block, .binfo.block.bdark
 filesdark.com##[href*="/adac.php"]
 centrumdruku3d.pl##a[href^="https://goo.gl/"]
 fiatklubpolska.pl##.body_wrapper > div > A
-film.interia.pl,geekweek.interia.pl,kobieta.interia.pl,motoryzacja.interia.pl,muzyka.interia.pl,styl.interia.pl,swiatseriali.interia.pl,top.pl,zdrowie.interia.pl,zielona.interia.pl###feed_grupa.ad, .article-body__ad-gora-srodek
+e.sport.interia.pl,film.interia.pl,geekweek.interia.pl,kobieta.interia.pl,motoryzacja.interia.pl,muzyka.interia.pl,pogoda.interia.pl,styl.interia.pl,swiatseriali.interia.pl,top.pl,zdrowie.interia.pl,zielona.interia.pl###feed_grupa.ad, #ad-feed_grupa, .article-body__ad-gora-srodek, .mixerAdTopRight-wrapper, .has-mixerAdTopRight
 filmpolski.pl##.obrazek_bez_ramki
 filmweb.pl##.PlusDiscountsButton, .faHeaderBanner--html, .AdvertButton, .d_utru, .faBar.fa
 filmweb.pl##.faBannerPromo
@@ -1681,13 +1680,12 @@ interia.pl##[id^="ad_"]
 interia.pl##div[class*="ad ad_"]
 interia.pl,pomponik.pl,styl.pl##.inpl-gallery-ad-horizontal, .inpl-gallery-ad-side
 interia.pl##div[class^="box ad box"]
-interia.pl##.adStandardTop
+interia.pl##.adStandardTop, #feed_grupa.ad, #ad-feed_grupa, .article-body__ad-gora-srodek, .mixerAdTopRight-wrapper, .has-mixerAdTopRight
 interia.pl##.main-sidebar > div[style="height: 600px;"] > div[style^="max-width:"][style*="position: sticky"]
 interia.pl##.main-sidebar a[href][target="_blank"][onclick*="&creation="]
 interia.pl,pomponik.pl,styl.pl#?#div[style*="sticky"]:-abp-has(> .boxHeader ~ a[href][target="_blank"][onclick*="'polsat'"])
 interia.tv###belka_stopka1
 interia.tv###box300x2501
-interia.pl#?#.brief-list-item:-abp-has(> .mixerAdTopRight-wrapper:not(.has-noads))
 interia.pl##.ad-article-vertical-track, .ad-article-horizontal-wrapper
 interia.pl##[class^="ad-container "]
 interia.pl###sponsCont, .spons-ph
@@ -3295,7 +3293,7 @@ wirtualnemedia.pl,nowywyszkowiak.pl,eglos.pl##[id^="baner"]
 slowopodlasia.pl##.mw-15.main-widget, .widget-57.widget, .widget-82.widget
 slupca.pl##.g-2.g
 slupca.pl,gry-online.pl###baner-top
-smaker.pl##.advertBoxItem, .advert--container, .advert--spacer, .block--adv--padding
+smaker.pl##.advertBoxItem, .advert--container, .advert--spacer, .block--adv--padding, .advert--component, .advertComp
 smart-test.pl###jm-header, .jm-sample-block, .jm-module:nth-of-type(n+2)
 sms7.pl##DIV[style*="idth: 970px;"]
 sms7.pl##[id^="banner_"]
@@ -3949,7 +3947,7 @@ wterenie.pl,szczecinek.com##.fl.w1000
 wterenie.pl,pultusk24.pl##div.l-box--50.l-box > p
 wtk.pl##.clean-border.video-medium-tile
 wtkplay.pl##[id^="adsys_"]
-wydarzenia.interia.pl#?#div[class*=" "]:-abp-has( > [data-iwa-viewability-name] > .ad)
+wydarzenia.interia.pl,sport.interia.pl#?#div[class*=" "]:-abp-has( > [data-iwa-viewability-name] > .ad)
 wydarzenia.interia.pl###container-rectangle1, #container-rectangle2
 wydawajdobrze.com##.d-xl-block.d-none
 wypracowania.pl##[style^="width:640px;margin:0 auto; min-height: 360px"]
@@ -4032,7 +4030,7 @@ www.hopaj.pl###hopajembed
 www.imperiumromanum.edu.pl##[href^="https://www.empik.com/swiety-ogien-rzymu-wespazjan-tom-8-fabbri-robert,p1242140709,ksiazka-p"]
 www.imperiumromanum.edu.pl##[href="http://www.wydawnictwoatryda.pl/kolekcja/frontpage/aecjusz-i-barbarzyncy/"]
 www.interia.pl##section.wide-section > section > div > A > IMG
-www.interia.pl##.ad-content, .ad-window, .overlay
+www.interia.pl##.ad-content, .ad-window, .overlay, .common-ad, [id^="ad-banner_"]
 www.jaslo4u.pl###flashContent
 www.jaslo4u.pl###posters_slider
 www.kazimierzdolny.pl##.sidebar__widget:nth-of-type(1)
@@ -5100,6 +5098,7 @@ wykop.pl###wpladbottom, .stm-ad-player
 wykop.pl##.m-hide.m-reset-width.m-reset-margin.m-reset-float.grid-right > div.r-block > div > A > IMG
 ||wykop.pl/api/v*/ads
 wykop.pl##.pub-slot-wrapper
+wykop.pl##.ski-jumping-slider
 !
 !22#--------------------------Rules unblock protection------------!
 autocentrum.pl,demotywatory.pl,dziennik.pl,facetemjestem.pl,gala.pl,garnek.pl,jegostrona.pl,joemonster.org,kobieta.pl,komixxy.pl,transfery.info,v10.pl,prawdaobiektywna.pl##div > iframe[style^="border:"]:not([src])

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -1199,7 +1199,6 @@ filesdark.com##.btopnews.block, .binfo.block.bdark
 filesdark.com##[href*="/adac.php"]
 centrumdruku3d.pl##a[href^="https://goo.gl/"]
 fiatklubpolska.pl##.body_wrapper > div > A
-e.sport.interia.pl,film.interia.pl,geekweek.interia.pl,kobieta.interia.pl,motoryzacja.interia.pl,muzyka.interia.pl,pogoda.interia.pl,styl.interia.pl,swiatseriali.interia.pl,top.pl,zdrowie.interia.pl,zielona.interia.pl###feed_grupa.ad, #ad-feed_grupa, .article-body__ad-gora-srodek, .mixerAdTopRight-wrapper, .has-mixerAdTopRight
 filmpolski.pl##.obrazek_bez_ramki
 filmweb.pl##.PlusDiscountsButton, .faHeaderBanner--html, .AdvertButton, .d_utru, .faBar.fa
 filmweb.pl##.faBannerPromo

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 13 January 2024
+! Last modified: 15 January 2024
 ! Expires: 1 day
-! Version: 2024011301
+! Version: 2024011501
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2022 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024011301 aktualizacja: so, 13 stycznia 2024, 14:45:00
+! v.2024011501 aktualizacja: pon, 15 stycznia 2024, 10:45:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -441,6 +441,7 @@ prv.pl###prvAliasFrame2:style(height:calc(100vh - 10px) !important;)
 przegladpiaseczynski.pl##html[class].wppas-model-open:style(overflow: visible !important;)
 radom24.pl###pojemnik-strony:style(margin-top: 0 !important;)
 spidersweb.pl##.playstation.wall-bg:style(background: none !important;)
+sprzedajemy.pl##.layWrpMarginTopAdsDesktop:style(margin-top: 0px !important)
 tabletowo.pl###main_header:style(margin-top: 0 !important;)
 tv-wschod.pl##.widget:style(margin: 10px -15px 0 0 !important;)
 tv-wschod.pl##section.container:style(padding-top: 0 !important;)


### PR DESCRIPTION
**Reklamy / puste kontenery/napisy po reklamach :**

**1]** GRUPA INTERIA.PL fix #20301
(dalsza naprawa, (już trzeci raz) bo jeszcze jakieś kontenery zostały) :

Desktop, kilkanaście stron :
`*.interia.pl` fix #15133 - głównie kontenery po prawej, oraz kilka innych

Mobile, trzy strony : 
`www.interia.pl` fix #16783 - kilkanaście kontenerów
`sport.interia.pl` fix #21482- kilkanaście kontenerów
`smaker.pl` - jeden kontener 

Przy okazji sklejka 2 filtrów w jeden: `czateria.interia.pl`

**2]** `wykop.pl` - fix #15022, fix https://github.com/AdguardTeam/AdguardFilters/issues/170628 - reklama u góry
**3]** `businessinsider.com.pl` - fix https://github.com/AdguardTeam/AdguardFilters/issues/148382 - reklama po prawej w artykułach
**4]** `sprzedajemy.pl` - fix https://github.com/MajkiIT/polish-ads-filter/issues/22240, fix https://github.com/AdguardTeam/AdguardFilters/issues/142355 - pusty kontener u góry
**5]** `kontomaniak.pl` - fix https://github.com/MajkiIT/polish-ads-filter/issues/22241 - reklama na środku