### PR TITLE
Update adblock.txt + adblock_ublock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5680,8 +5680,7 @@ avanti24.pl##.art_embed
 avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
-sport.pl,edziecko.pl,avanti24.pl,plotek.pl##[id^="DFP-011-MIDBOARD_"], #banC99, .ban001_wrapper, #banC1
-edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [id^="DFP-"], [id^="adsMidboardDivId_"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv
+avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -2893,6 +2893,7 @@ portalwrc.pl##.djslider-loader-default.djslider-loader
 portalsamorzadowy.pl##.box-1 > .left
 portalsremski.pl##div[class^="ban"]
 portaltatrzanski.com##.promo-baner
+portalzp.pl##[id^="baner-"], [id^="adoceanmy"]
 poscigi.pl###rev_slider_1_1_wrapper, .td_block_image_box.td_block_wrap, #rev_slider_4_1, [id^="bsa-block-"], #rev_slider_5_2_wrapper, .fadeIn.animated, .code-block-6.code-block, .bsaProItemInner__html
 posshop.pl###box_custom3
 postawnaswoim.pl##.size-full.alignnone

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 16 January 2024
+! Last modified: 19 January 2024
 ! Expires: 1 day
-! Version: 2024011601
+! Version: 2024011901
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2024 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024011601 aktualizacja: wt, 16 stycznia 2024, 12:55:00
+! v.2024011901 aktualizacja: pt, 19 stycznia 2024, 20:31:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -322,7 +322,7 @@ zlotowskie.pl#?#[class="card  card--box"]:not(:-abp-has([href*="/ligi/"]))
 4lomza.pl##.bxbanner
 4lomza.pl,zambrow.org,miedziowe.pl,miastociechocinek.com##[id*="banner"]
 4programmers.net###container-fluid > div > A[target="_blank"], .revive
-4run.pl,abcjanikowo24.pl,asta24.pl,bp24.pl,brodnica365.pl,bydgoszcz24.pl,chelmza365.pl,chocianow.com.pl,ciechocinek.biz,ddtorun.pl,ddwloclawek.pl,dziennikpowiatowy.pl,e-chelmno.pl,e-krajna.pl,eglos.pl,ejarocin.pl,ekstrasierpc.pl,ekutno.pl,eluban.pl,esopot.pl,expresskaszubski.pl,extrawalcz.pl,faktyct.pl,faktypilskie.pl,gle24.pl,gniewkowo.eu,gorlice24.pl,gostyn24.pl,grudziadz365.pl,gst24.pl,gwe24.pl,gwio.pl,hej.mielec.pl,ibytow.pl,infomogilno24.pl,ipoddebice.pl,isanok.pl,iszczecinek.pl,itvszubin.pl,jastrowie24.pl,ki24.info,kolniak24.pl,koronowo.net.pl,korso.pl,kozieglowy365.pl,leszno24.pl,mgr.far,miastko24.pl,mojakruszwica.pl,naklo.fm,naszradziejow.pl,naszrynek.pl,nizanskie.info,pakosc24.pl,plonskwsieci.pl,polskicaravaning.pl,portalplock.pl,portalsremski.pl,portalwloclawek.pl,pszczynska.pl,pulsciechanowa.pl,roztocze.net,rzeczkrotoszynska.pl,sompolno24.pl,sportowebeskidy.pl,spotradomsko.pl,superchodziez.pl,swiecie24.pl,tarnowska.pl,terazgabin.pl,terazgostynin.pl,terazlipno.pl,tusochaczew.pl,tygodnik.pl,uniejow.net.pl,walbrzych365.pl,wiadomoscihandlowe.pl,wiadomoscikosmetyczne.pl,wiescimiedzychodzkie.pl,wkikole.pl,wrzesnia.info.pl,zachodniopomorska.tv,zyciesiedleckie.pl,zyciesokolowa.pl##.topLayer, .new-toplayer, .baner
+4run.pl,abcjanikowo24.pl,asta24.pl,bp24.pl,brodnica365.pl,bydgoszcz24.pl,chelmza365.pl,chocianow.com.pl,ciechocinek.biz,ddtorun.pl,ddwloclawek.pl,dziennikpowiatowy.pl,e-chelmno.pl,e-krajna.pl,eglos.pl,ejarocin.pl,ekstrasierpc.pl,ekutno.pl,eluban.pl,esopot.pl,expresskaszubski.pl,extrawalcz.pl,faktyct.pl,faktypilskie.pl,fakty.nl,gle24.pl,gniewkowo.eu,gorlice24.pl,gostyn24.pl,grudziadz365.pl,gst24.pl,gwe24.pl,gwio.pl,hej.mielec.pl,ibytow.pl,infomogilno24.pl,ipoddebice.pl,isanok.pl,iszczecinek.pl,itvszubin.pl,jastrowie24.pl,ki24.info,kolniak24.pl,koronowo.net.pl,korso.pl,kozieglowy365.pl,leszno24.pl,mgr.far,miastko24.pl,mojakruszwica.pl,naklo.fm,naszradziejow.pl,naszrynek.pl,nizanskie.info,pakosc24.pl,plonskwsieci.pl,polskicaravaning.pl,portalplock.pl,portalsremski.pl,portalwloclawek.pl,pszczynska.pl,pulsciechanowa.pl,roztocze.net,rzeczkrotoszynska.pl,sompolno24.pl,sportowebeskidy.pl,spotradomsko.pl,superchodziez.pl,swiecie24.pl,tarnowska.pl,terazgabin.pl,terazgostynin.pl,terazlipno.pl,tukutno.pl,tusochaczew.pl,tygodnik.pl,uniejow.net.pl,walbrzych365.pl,wiadomoscihandlowe.pl,wiadomoscikosmetyczne.pl,wiescimiedzychodzkie.pl,wkikole.pl,wrzesnia.info.pl,zachodniopomorska.tv,zyciesiedleckie.pl,zyciesokolowa.pl##.topLayer, .new-toplayer, .baner
 6obcy.com.pl##.g2a
 7dni.pila.pl###text-3, #text-4, #text-17, #text-11, #text-13, #text-2, #text-12, #text-10, #text-26, #text-25
 7dni.pila.pl##[id*="_bid_"]
@@ -418,7 +418,7 @@ antyfake.pl,biznesinfo.pl,domekiogrodek.pl,goniec.pl,kobieta.swiatgwiazd.pl,lelu
 antyfake.pl,biznesinfo.pl,domekiogrodek.pl,goniec.pl,kobieta.swiatgwiazd.pl,lelum.pl,pacjenci.pl,portalparentingowy.pl,rolnikinfo.pl,rozrywka.goniec.pl,rozrywka.lelum.pl,smakosze.pl,sport.goniec.pl,swiatgwiazd.pl,swiatzwierzat.pl,tech.biznesinfo.pl,turysci.pl,wiadomosci.goniec.pl#?#.w-full > .items-center[style*="min-height:"]:-abp-has(> .ad-placeholder)
 antykwariatgelber.pl###content-sidebar
 antyweb.pl##.group.big.box-img
-antyweb.pl,ddwloclawek.pl##.banner--placeholder
+antyweb.pl,ddwloclawek.pl,fakty.nl,tukutno.pl##.banner--placeholder
 antyweb.pl##.group.no-margin.columns-wrapper > .group.no-margin.columns-wrapper
 antyweb.pl##.touch + IMG.notMobile[src*="/1200x400"]
 antyweb.pl##.transparent, .box-adv, .grid-item--height-2.grid-item--width-2.grid-item
@@ -564,7 +564,7 @@ bithub.pl##.gpuajs-image
 biznes-firma.pl##.navibox
 biznes.pl##.e_Box.analyses
 biznes.pl##.rightBoxR.boxPopComtR.cl
-biznes.interia.pl,geekweek.interia.pl,muzyka.interia.pl##.promocyjni_gazetka_dol, .ad-rectangle
+biznes.interia.pl,geekweek.interia.pl,gry.interia.pl,muzyka.interia.pl##.promocyjni_gazetka_dol, .ad-rectangle
 biznes2biznes.com##DIV[style="width:200px;float:right;display:block;margin-left:-5px;"]
 biznes2biznes.com##[id^="stickynote"]
 biznesalert.pl##.banner-overlay, .container > div:nth-of-type(10)
@@ -946,7 +946,7 @@ dziennikwschodni.pl##[id^="\37"]
 dziennikwschodni.pl##.l-content > [style="display: flex; justify-content: center; margin-top: 15px; margin-bottom: 15px;"]
 dziennikzachodni.pl,kurierlubelski.pl,pomorska.pl##.gry
 dzierzgon.info.pl,twojepajeczno.pl##.textwidget
-dzisiajwgliwicach.pl###text-32
+dzisiajwgliwicach.pl,lubaczow.tv###text-32
 dzisiajwgliwicach.pl##.entry > [class]
 dzisiajwgliwicach.pl##.entry > [href]
 dzisiajwgliwicach.pl##img[src*="Baner-590x300-"]
@@ -1016,6 +1016,7 @@ egorzow.pl,tudeblin.pl##.l-box--100.l-box > p
 egryfino.pl##a[href^="/r/"]
 eholiday.pl###appear_event
 eholiday.pl##.rectangles, .box-promo-title
+ehumor.pl,glosgminny.pl###text-30
 eioba.pl###adsPanelTopt
 ekino-tv.pl##.col-md-9 > [href^="http"]
 ekologia.pl###pasaz-wid, #wi-58
@@ -1392,7 +1393,8 @@ gazetki-promocyjne.net.pl##.shadow-text
 gazetkonosz.pl###overlayAd
 gazetkonosz.pl##.signad
 gdzietymrazem.pl##.widget_text.widget.td_block_template_1:nth-of-type(4)
-geekweek.interia.pl##.dol_srodek_ads_box
+geekweek.interia.pl##.dol_srodek_ads_box, .adStandardTop, #feed_grupa.ad, #ad-feed_grupa, .article-body__ad-gora-srodek
+geekweek.interia.pl##header + ul > .has-mixerAdTopRight
 geoforum.pl###advertisement_div
 geoforum.pl,eurobuildcee.com,dziennikprawny.pl,fachowcybudowlani.pl##.banery
 getlevel.info###cb-section-b > .clearfix.cb-sidebar
@@ -1418,7 +1420,6 @@ gloria.tv##A[href^="/advertisement/"]
 gloria.tv##footer
 glos.live###second_col
 glos24.pl##IMG[src^="/files/adv/"]
-glosgminny.pl###text-30
 gloskoninski.pl##.widget-area.hero-area
 glosmordoru.pl###panel-506-2-0-0, .widget_vmagazine_lite_medium_ad
 glospedagogiczny.pl##.loaded.auto-pr-block__desktop.picture.lazy-image
@@ -1515,6 +1516,7 @@ gry-online.pl##[class$="-stopka"]
 gry-online.poszkole.pl###pixad
 gry-online.poszkole.pl##.ad-info, .word-txt > A > IMG
 gry-online.pl,futurebeat.pl###baner-outer
+gry.interia.pl##.dol_srodek_ads_box
 gry.misiakowo.pl##[style$="width:346px;height:290px;"]
 gry.misiakowo.pl##[style="width:100%;max-width:800px;overflow:auto;"] + H2
 grydladzieci.biz.pl###mmm2
@@ -1679,7 +1681,7 @@ interia.pl##[id^="ad_"]
 interia.pl##div[class*="ad ad_"]
 interia.pl,pomponik.pl,styl.pl##.inpl-gallery-ad-horizontal, .inpl-gallery-ad-side
 interia.pl##div[class^="box ad box"]
-interia.pl##.adStandardTop, #feed_grupa.ad, #ad-feed_grupa, .article-body__ad-gora-srodek, .mixerAdTopRight-wrapper, .has-mixerAdTopRight
+interia.pl,~geekweek.interia.pl##.adStandardTop, #feed_grupa.ad, #ad-feed_grupa, .article-body__ad-gora-srodek, .mixerAdTopRight-wrapper, .has-mixerAdTopRight
 interia.pl##.main-sidebar > div[style="height: 600px;"] > div[style^="max-width:"][style*="position: sticky"]
 interia.pl##.main-sidebar a[href][target="_blank"][onclick*="&creation="]
 interia.pl,pomponik.pl,styl.pl#?#div[style*="sticky"]:-abp-has(> .boxHeader ~ a[href][target="_blank"][onclick*="'polsat'"])
@@ -1810,6 +1812,7 @@ jysk.promoceny.pl###mbImage
 jysk.promoceny.pl###mbOverlay
 kalendarzswiatnietypowych.pl##.widget-area.featured-sidebar
 kalisz24.info.pl##.theiaStickySidebar > .widget_text
+kalkulatorwaluty.pl##.elementor-section-wrap > [data-settings='{"background_background":"classic"}']
 kalwaria24.pl##.newspaper-x-image-banner
 kamienskie.info##.ads-subpage
 kanal10.pl##[class*="banner_"]
@@ -2020,6 +2023,7 @@ lfc.pl##center
 lider.eu##.reveal-overlay
 liderbudowlany.pl##.topbar.row > .col-lg-9.col-12, .banner.hp-promo
 lifeinkrakow.pl##.image > A > .lazyloaded
+limanowa.in##.floatingArd, .ardContainer--fluid.ardContainer, .ad-placeholder__sky, #topBarner
 limanowianin.in##.tb_ro13041.module_row_6600-5.themify_builder_6600_row.module_row_5.fullwidth_row_container.fadeIn.wow.fullcover.clearfix.module_row.themify_builder_row, .slide-13819.slider-13815
 ling.pl###arboBig
 linguajob.pl###flash_baner, #praca-u-najlepszych
@@ -2311,6 +2315,7 @@ mobileclick.pl###text-40
 mobileclick.pl#?#[id^="text-"]:-abp-has(.widget-title:-abp-contains(Reklama))
 mobileclick.pl#?#.post > .entry-content > h4:-abp-contains(Reklama)
 mobileclick.pl###post-25393 > .entry-content > h4
+mobiletrends.pl##.sidebar > .mt-5.text-center
 mobilneforum.pl##.resp-container
 mobileworld24.pl###text-4
 mobilitynews.pl##.a-single, .banner_header
@@ -2467,8 +2472,11 @@ naszemiasto.pl#?#.componentsArticleContent ul:-abp-has(a[href*="ceneo.pl"])
 naszemiasto.pl##.componentsArticleContent a[href*="ceneo.pl"]
 naszestrony.info.pl##.nopad > div > A > IMG
 naszesudety.pl###column2 > .box
-naszraciborz.pl,naszrybnik.com##.news_box_google, .news_box_reklama
+naszraciborz.pl,naszrybnik.com,viapoland.com##.news_box_google, .news_box_reklama
 naszraciborz.pl,naszrybnik.com##.adsense_title
+naszraciborz.pl,naszwodzislaw.com##.reklama_box, .reklama_title, .title_ads, .grey_ad
+naszraciborz.pl,naszwodzislaw.com#?#.grey:-abp-has(>.site_ad)
+naszrybnik.com###skyscraper2
 tonaszregion.pl###media_image-13, #media_image-121, #media_image-49, #media_image-77, #media_image-136
 naszsrem.pl##.elementor-widget-image.elementor-widget.elementor-element-4e198b9.elementor-element > .elementor-widget-container > .elementor-image
 nasztomaszow.pl###popup_our
@@ -2714,6 +2722,7 @@ perfumik.pl###popup_start
 perspektywy.pl##[href*="/click_baner.php"], aside > div.moduletable > div.module-banner > A[target="_blank"] > IMG
 petronews.pl##.gloto, #moving-banner-container, div.wpb_content_element.wpb_text_column
 petronews.pl##.vc_box_border_grey.vc_single_image-wrapper > .attachment-full.vc_single_image-img
+pfmrc.eu###ipsLayout_mainArea > center
 piekary.pl##.mfp-content
 piekary.pl##.mfp-ready
 pielegniarki.info.pl###gsk, .center-block
@@ -3060,6 +3069,8 @@ radiopik.pl##.promo, .rma
 radiopiekary.pl##.size-full.wp-image-44846441.aligncenter, #text-49, #text-73, #text-76, #text-77, #cycloneslider-baner-1, #text-78
 radioplus.com.pl##.moduletable:nth-of-type(3), .moduletable:nth-of-type(4)
 radioplus.pl###bottom-ad
+radioq.fm##.sppb-slide, .sppb-addon-raw-html, #sp-reklama
+radioq.fm##[href="https://karta.kutno.pl/"]
 radioradom.pl###itro_opaco, #itro_popup
 radiorodzina.pl##.left-large-ad
 radiorsc.pl##div.margin-bottom30:nth-of-type(5) > .greybox
@@ -3305,7 +3316,7 @@ softonet.pl##A[data-redirect^="http://click.plista.com/redirect.php"]
 softonet.pl##A[href^="http://click.plista.com/pets/"]
 softonic.pl##[id^="show_banner_"]
 sokolka.tv###jm-left > div > div.white-ms.jm-module
-sokolka.tv###jm-top1
+sokolka.tv###jm-top1, .white-ms, #jm-content-top
 sokolka.tv##.hidden-phone.white-ms.jm-module, #jm-header-content-in, div.itemContainerLast.itemContainer > .moduletable
 solarkurier.pl###banner_750x100_r
 solarkurier.pl##.row:nth-of-type(2) > .col-xs-8.col-md-3:nth-of-type(4)
@@ -3661,6 +3672,7 @@ tv.pl###b11
 tv.pl##.win > div > A
 tvdzierzgon.pl##.affix.offbox-widget > .swiper-slide
 tvdzierzgon.pl,tvmalbork.pl,tvregionalna24.pl,tvsztum.pl,zulawyimierzeja24.pl##.advert-B1
+tvgniezno.pl##.rotator-file
 tvgorzow.pl###testimonialrotatorwidget-5
 tvjaslo.pl###text-5
 tvjaslo.pl##.bx-viewport
@@ -3858,7 +3870,7 @@ widzewtomy.net##.wp-image-55746.image
 wieleliter.pl##.wiele-widget.widget
 wielkahistoria.pl#?##custom_html-5:-abp-has(.adsbygoogle)
 wielkiebudowanie.pl##.banerjpg
-wielkopolska.tv##.ineaBox.boxHeader
+wielkopolska.tv##.ineaBox.boxHeader, #ai_widget-2
 wielkopolska24.info###ai_widget-3
 wielodzietni.org##[id^="reklama-"]
 wiesci.info.pl#?#h4:-abp-contains(REKLAMA)
@@ -4635,6 +4647,7 @@ zywiecinfo.pl##[href*="/component/banners/click/"]
 ||reklamawadowice24.pl^$image
 ||reklamy.s3.amazonaws.com/bcg/$image
 ||reklamy.grupafarmacja.net^
+||reklamy.naszraciborz.pl^
 ||repostuj.pl/static/repostujpl/arrow_right.jpg$domain=repostuj.pl
 ||request.dqst.pl/$xmlhttprequest
 ||rkantor.com/widget/$script,domain=~poczta-polska.pl
@@ -5261,9 +5274,12 @@ srkcast.com##[id^="table"]
 ||privatestream.tv/logo^
 !
 !31#--------------------------WP Group element hide------------!
+abczdrowie.pl##[data-element="wide-placeholder"]
 autokult.pl##.insert--top-offer.insert, .partner-area
 autokult.pl##[href^="http://corto.www.wp.pl/"]
 avent-ugrow.wp.pl##[class$="BgClick"]
+forum.benchmark.pl##div[id][style$="display:flex;justify-content:center;align-items:center"]
+horoskop.wp.pl##div[class*="reklama_"]
 kafeteria.pl,money.pl,pudelek.pl,autokult.pl##.scr-wallpaper
 kafeteria.pl,nerwica.com##.article__side
 komorkomania.pl##.align-center.insert--size-m.insert
@@ -5274,6 +5290,7 @@ komorkomania.pl,gadzetomania.pl,fotoblogia.pl,autokult.pl,wawalove.pl##FIGURE.in
 kuchnia.wp.pl#?#body > div:-abp-has( > div > a[href])
 kuchnia.wp.pl##td > div[style="position: relative; top: 0px;"]
 o2.pl##A[href*=".wp.pl/"][target="_blank"] > DIV[style^="background-color: rgb"]
+o2.pl##div[data-testid^="ad-placeholder-"]
 o2.pl,gadzetomania.pl##A[href*=".wp.pl/"][target="_blank"] > IMG[class][src^="https://v.wpimg.pl/"]
 open.fm###ADrail
 open.fm###openfm-player > DIV[class] > DIV[class]
@@ -5285,15 +5302,17 @@ open.fm##[class^="bnr-player-"]
 !pogoda.wp.pl#?#.desktop > div:nth-of-type(4):-abp-has(div:empty)
 !pogoda.wp.pl#?#.desktop > div:nth-of-type(7):-abp-has(div:empty)
 pogoda.wp.pl#?#.narrow.grid-right > div:nth-of-type(1):-abp-has(div:empty)
+pogoda.wp.pl#?#.desktop > div[class*=" "]:-abp-has(div)
+pogoda.wp.pl##div[class^="placeholder_"]
 portal-abczdrowie.wp.pl##.article__side__stickblock, .article__textbox
 portal.abczdrowie.pl##.article__textbox
 portal.abczdrowie.pl##.sidebar-box--promo
 portal.abczdrowie.pl##A[target="_blank"] > IMG[src^="https://v.wpimg.pl/"]
 portal.abczdrowie.pl##[class^="article__side__stickblock-"]
+ranking.abczdrowie.pl#?#div[class]:-abp-has(>div>iframe)
 wawalove.pl##.floating-ad.advertisement
 wawalove.pl##a[href="http://dajsygnal.pl/"]
 wawalove.pl,pytamy.pl,dzieci.pl##[id^="adv"]
-pogoda.wp.pl#?#.desktop > div[class*=" "]:-abp-has(div)
 !
 !32#--------------------------WP element block------------!
 ||i.wp.pl/*/stg/wpjslib-nojq.js$script,domain=www.dobreprogramy.pl
@@ -5336,9 +5355,11 @@ wiadomosci.wp.pl##[target="_blank"] > IMG[src^="https://v.wpimg.pl/"]
 wiadomosci.wp.pl,gwiazdy.wp.pl,teleshow.wp.pl##A[href*=".wp.pl/"][target="_blank"]:first-child > FIGURE[class^="_"]
 wiadomosci.wp.pl,tech.wp.pl,kobieta.wp.pl,gwiazdy.wp.pl,teleshow.wp.pl##A[class^="_"][href*=".wp.pl/"][target="_blank"] > FIGURE[class^="_"] + * H3[class*="teaser"]
 wp.pl##.scr-wallpaper
+wp.pl##a[href^="https://ad.doubleclick.net/"]
 wp.pl##body > iframe + iframe + #pushpushgo-container + div:not([id])[class]
 www.o2.pl##.gzuwb
 www.wp.pl###newsfeed-player-column[class^="_3"] > DIV[class^="sc-"]
+www.wp.pl###site-header > div:first-child
 www.wp.pl##[class*="AdvSlotWithPlaceholder__"]
 www.wp.pl##[id^="sgwp_screening_"]
 www.wp.pl##aside > div[class*=" "][height]:not([mode])
@@ -5346,6 +5367,7 @@ www.wp.pl##body > div[class*=" "]:not([id])
 www.wp.pl##div > div[class*=" "][height]:not([mode])
 www.wp.pl##div[class][data-st-area="Naglowek-duzy"] a[href^="https://radar.wp.pl/"]
 www.wp.pl##div[class][data-st-area="kokpitPolecane"]
+www.wp.pl##div[data-section="premium"] > div:first-child
 www.wp.pl#?#div[class^="sc-"]:-abp-has(> img[src="//v.wpimg.pl/LTc0NzY1JT1MBXgCbQRjPU1HPlQpXWM1TFlhCS1WYyQIVmEYPh88OgQ=/"])
 www.wp.pl#?#div[class*=" "]:-abp-has(> img[src$="/i.wp.pl/a/i/stg/pkf/bg.png"])
 ~wideo.wp.pl,~www.wp.pl,wp.pl##A[href*=".wp.pl/"] > DIV > IMG[class][src^="https://v.wpimg.pl/"]
@@ -5355,10 +5377,13 @@ www.wp.pl#?#div[class*=" "]:-abp-has(> img[src$="/i.wp.pl/a/i/stg/pkf/bg.png"])
 ~www.wp.pl,wp.pl##body > script + iframe + div:not([id])[class]
 pogoda.wp.pl##li > .item + div[class*=" "]
 @@||o2.pl^$generichide
-! against blinking ads (https://github.com/MajkiIT/polish-ads-filter/pull/22235) :
+! against blinking top ads (https://github.com/MajkiIT/polish-ads-filter/pull/22235) :
 fitness.wp.pl#?#.article-wrapper.wizard-body > div:not([class*="-"]):-abp-has(> img[src^="https://i.wpimg.pl/100x0/m.autokult.pl/"])
 wideo.wp.pl#?#header + div + style + div:-abp-has(>[src="https://std.wpcdn.pl/images/adv/placeholder_wp.svg"])
 wideo.wp.pl#?#header + style + div:-abp-has(>[src="https://std.wpcdn.pl/images/adv/placeholder_wp.svg"])
+sportowefakty.wp.pl##header.page-header + div:not([class])
+sportowefakty.wp.pl##body > div.bg-block + div[class]:not([id])
+sportowefakty.wp.pl##main#content.content > div[class]:first-child + div[class]
 !
 !34#--------------------------Pudelek/Pudelekx element hide------------!
 pudelek.pl##DIV.cb > DIV[class^="m"]
@@ -5393,6 +5418,7 @@ money.pl##.x03, .linia, .mpl_right > [class] > [class] > div > div
 money.pl##.recommended
 money.pl##A[href*="://direct.money.pl/o/salechannel.php"]
 money.pl##DIV[style$="min-height:180px"]
+money.pl##iframe[src*="promoted"]
 msp.money.pl##DIV > DIV[style*=" z-index: 310"]
 prawo.money.pl###img11155698
 www.money.pl###ADrail > DIV > DIV[class]

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5677,10 +5677,11 @@ spidersweb.pl,topagrar.pl##a[href*="hit.gemius.pl/"]
 !
 !44#--------------------------Agora ADS------------!
 avanti24.pl##.art_embed
+avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
 sport.pl,edziecko.pl,avanti24.pl,plotek.pl##[id^="DFP-011-MIDBOARD_"], #banC99, .ban001_wrapper, #banC1
-avanti24.pl##.svelte-p8mgmp.inner-ban
+edziecko.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [id^="adsMidboardDivId_"], .ren-banners--, .banIndexDFP, .banEntry, #DFP-080-MIDBOARD-BOTTOM
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5680,7 +5680,7 @@ avanti24.pl##.art_embed
 avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
-avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner
+avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,magazyn-kuchnia.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5680,7 +5680,7 @@ avanti24.pl##.art_embed
 avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
-avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,magazyn-kuchnia.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner
+avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,magazyn-kuchnia.pl,moto.pl,plotek.pl,sport.pl,tokfm.pl,ukrayina.pl,wyborcza.biz##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner, .activeBan
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5681,7 +5681,7 @@ avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
 sport.pl,edziecko.pl,avanti24.pl,plotek.pl##[id^="DFP-011-MIDBOARD_"], #banC99, .ban001_wrapper, #banC1
-edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [id^="DFP-"], [id^="adsMidboardDivId_"], .ren-banners--, .banIndexDFP, .banEntry
+edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [id^="DFP-"], [id^="adsMidboardDivId_"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5681,7 +5681,7 @@ avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
 sport.pl,edziecko.pl,avanti24.pl,plotek.pl##[id^="DFP-011-MIDBOARD_"], #banC99, .ban001_wrapper, #banC1
-edziecko.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [id^="adsMidboardDivId_"], .ren-banners--, .banIndexDFP, .banEntry, #DFP-080-MIDBOARD-BOTTOM
+edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [id^="DFP-"], [id^="adsMidboardDivId_"], .ren-banners--, .banIndexDFP, .banEntry
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -5680,7 +5680,7 @@ avanti24.pl##.art_embed
 avanti24.pl##.svelte-p8mgmp.inner-ban
 avanti24.pl##products-nativegallery
 sport.pl##.cg4-ad, .mod_uzr_sport6.mod
-avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner
+avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##[id^="banC"], [id^="banP"], [class^="ban0"], [class*="DFP-"], [id^="DFP-"], [id^="adsMidboardDivId_"], [id^="adUnit"], .ren-banners--, .banIndexDFP, .banEntry, .indexPremium__adv, .adviewDFPBanner
 !
 !45#--------------------------shinden.pl------------!
 ||spolecznosci.net/js/modules/sfw.js$important,domain=shinden.pl

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -403,7 +403,7 @@ poczta.interia.pl#$##mainApp #sitebar, #mainApp #sitebar form { width: 100% !imp
 interia.pl,pomponik.pl##.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links:style(display: block !important;)
 !
 ! Grupa Agora
-avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##+js(set, dfpParams.slots, null)
+avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,komunikaty.pl,magazyn-kuchnia.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##+js(set, dfpParams.slots, null)
 !
 ! elektroda.pl
 www.elektroda.pl##+js(set, loadElement, noopFunc)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -403,7 +403,7 @@ poczta.interia.pl#$##mainApp #sitebar, #mainApp #sitebar form { width: 100% !imp
 interia.pl,pomponik.pl##.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links:style(display: block !important;)
 !
 ! Grupa Agora
-avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,komunikaty.pl,magazyn-kuchnia.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##+js(set, dfpParams.slots, null)
+avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,komunikaty.pl,magazyn-kuchnia.pl,moto.pl,plotek.pl,sport.pl,tokfm.pl,ukrayina.pl,wyborcza.biz##+js(set, dfpParams.slots, null)
 !
 ! elektroda.pl
 www.elektroda.pl##+js(set, loadElement, noopFunc)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -403,7 +403,7 @@ poczta.interia.pl#$##mainApp #sitebar, #mainApp #sitebar form { width: 100% !imp
 interia.pl,pomponik.pl##.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links:style(display: block !important;)
 !
 ! Grupa Agora
-edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##+js(set, dfpParams.slots, null)
+avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##+js(set, dfpParams.slots, null)
 !
 ! elektroda.pl
 www.elektroda.pl##+js(set, loadElement, noopFunc)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -402,6 +402,9 @@ www.interia.pl##+js(nano-stb, #iwa_source=timeout, 15000, 0.02)
 poczta.interia.pl#$##mainApp #sitebar, #mainApp #sitebar form { width: 100% !important; max-width: 100% !important }
 interia.pl,pomponik.pl##.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links:style(display: block !important;)
 !
+! Grupa Agora
+edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##+js(set, dfpParams.slots, null)
+!
 ! elektroda.pl
 www.elektroda.pl##+js(set, loadElement, noopFunc)
 !

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 15 January 2024
+! Last modified: 19 January 2024
 ! Expires: 1 day
-! Version: 2024011501
+! Version: 2024011901
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2022 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024011501 aktualizacja: pon, 15 stycznia 2024, 10:45:00
+! v.2024011901 aktualizacja: pt, 19 stycznia 2024, 20:31:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -154,7 +154,7 @@ filmweb.pl##+js(nano-remove-elements-onready.js, #skyBanner)
 ! Grupa WP
 !~www.wp.pl,abczdrowie.pl,parenting.pl,kafeteria.pl,money.pl,dobreprogramy.pl,wp.pl##+js(set, Number.isNaN, trueFunc)
 !~www.wp.pl,wp.pl##+js(set, wp_abtest, null)
-~www.wp.pl,o2.pl,~poczta.o2.pl,pudelek.pl,wp.pl##div:matches-css-after(content:/R.*E.*K.*L.*A.*M.*A/):upward(1)
+~www.wp.pl,o2.pl,~poczta.o2.pl,ranking.abczdrowie.pl,pudelek.pl,wp.pl##div:matches-css-after(content:/R.*E.*K.*L.*A.*M.*A/):upward(1)
 ~pilot.wp.pl,~poczta.wp.pl,~sportowefakty.wp.pl,wp.pl##+js(aopr, WP.inline)
 !abczdrowie.pl,echirurgia.pl,fotoblogia.pl,komorkomania.pl,money.pl,wp.pl##+js(set, PWA_adbd, 2)
 facet.wp.pl,gwiazdy.wp.pl,teleshow.wp.pl##+js(aopw, iaqExt)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -403,7 +403,7 @@ poczta.interia.pl#$##mainApp #sitebar, #mainApp #sitebar form { width: 100% !imp
 interia.pl,pomponik.pl##.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links:style(display: block !important;)
 !
 ! Grupa Agora
-avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl##+js(set, dfpParams.slots, null)
+avanti24.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl,wyborcza.biz##+js(set, dfpParams.slots, null)
 !
 ! elektroda.pl
 www.elektroda.pl##+js(set, loadElement, noopFunc)


### PR DESCRIPTION
**Reklamy / puste kontenery/napisy po reklamach :**

**1]** Poprawka do Grupy INTERIA.PL fix #20301 :
`geekweek.interia.pl` - naprawa lekkiego uszkodzenia ( https://github.com/MajkiIT/polish-ads-filter/issues/20301#issuecomment-1894155552 )
`gry.interia.pl` - kilka pustych kontenerów po reklamach

**2]** Grupa Studio Magromedia (kilka stron) : 
fix #22242, fix #22243, fix #22244, fix #22245

**3]** Grupa SIECPORTALI.PL (dodanie 2 stron)  :  fix #22256

**4]** Grupa AGORA.PL (kilkanaście stron) : naprawa wielu pustych kontenerów :
`edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,moto.pl,plotek.pl,sport.pl,ukrayina.pl`
fix #7638, fix #21667, fix https://github.com/uBlockOrigin/uAssets/issues/22085

**5]** Grupa Wirtualna Polska : 
fix #2497, fix #4037, fix #7533, fix #13818, f-i-x #18472
 - przeniesienie kilku stabilnych filtrów z uAssets do POL listy na prośbę jednego z wolontariuszy : 
fix https://github.com/uBlockOrigin/uAssets/issues/12214 + 
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1893873558
- `ranking.abczdrowie.pl` - naprawa wielu reklam/pustych kontenerów
( część poprzez doklejenie domeny do jednego z istniejącyh filtrów +
część poprzez utworzenie dodatkowego filtra własnej inwecji )
fix #5535, 
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1892804030 +
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1893679194 +
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1894104079
- `sportowefakty.wp.pl` - dodanie kilku filtrów anty-migających  własnej inwencji przeciwko górnym reklamom/kontenerom (desktop + mobile) (kontynuacja https://github.com/MajkiIT/polish-ads-filter/pull/22235)

**6]** Pozostałe strony (kilkanaście stron) :
fix #22246, fix #22247, fix #22248, fix #22249, fix #22250, 
fix #22251, fix #22252, fix #22253, fix #22254, fix #19268

f-i-x #22255 **(==> można usunąć etykietę `reklama`)**