### PR TITLE
Update adblock.txt + adblock_ublock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 19 January 2024
+! Last modified: 22 January 2024
 ! Expires: 1 day
-! Version: 2024011901
+! Version: 2024012201
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2024 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024011901 aktualizacja: pt, 19 stycznia 2024, 20:31:00
+! v.2024012201 aktualizacja: pt, 22 stycznia 2024, 22:00:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -704,7 +704,7 @@ chamsko.pl##.main-banner
 chamsko.pl##[href^="http://empire.goodgamestudios.com/"]
 charaktery.eu##.text.custom_popup.popup.window_popup, .promo_box
 chelmno.com.pl##body > p:nth-of-type(1)
-chelmski.eu##[class^="ad-single"], [class^="ad-home"], .reklamacenter
+chelmski.eu##[class^="ad-single"], [class^="ad-home"], .reklamacenter, .adigli, .block-type--adHome
 chilitonka.com##.wpcnt-header
 chillitorun.pl##.chill-adlabel
 chillizet.pl,antyradio.pl##.banner-radiostacja
@@ -730,6 +730,7 @@ chozoba.pl###title
 chroma.pl##.uv3dpopup-adv
 chrzanowski24.pl##.custom-rektt
 chrzanowski24.pl##div.moduletable > .custom > p
+chwaszczyno.pl##[data-widget_type="jet-images-layout.default"]
 chwilowo.pl##.baner-side
 ciapkowo.pl###execphp-3
 ciechanowinaczej.pl##.row:nth-of-type(3) > .fl.w250, .l-box--66.l-box > p
@@ -817,6 +818,7 @@ czest.info###block-block-21 > .block-inner > .content
 czest.info##.odd.region-odd.first.block-block.block
 czest.info###block-block-5 > .block-inner > .content
 czest.info###logo-title > A > IMG
+czest.info###block-block-22, #block-block-23, #block-block-4
 czesci-rolnicze-online.pl##.widget_media_image.first.widget
 czluchow.com.pl##.wrap
 czluchow.com.pl##td > table > tbody > tr > td:nth-of-type(3)
@@ -1021,7 +1023,8 @@ eioba.pl###adsPanelTopt
 ekino-tv.pl##.col-md-9 > [href^="http"]
 ekologia.pl###pasaz-wid, #wi-58
 ekorodzice.pl###ad_allLayer, .a_dr300.a_dslot
-ekoscian.eu##[id^="ekosc-"]
+ekoscian.eu##[id^="ekosc-"], #block-16, #block-23, #block-74, #block-81, #block-85
+ekoscian.eu##.clr.widget_media_gallery.widget_block.sidebar-widget
 eksiazki.az.pl##.alternatywa
 ekspresjaroslawski.pl##div.l-box--50.l-box > p > iMG
 ekstrastats.pl##div.clr.widget_text.widget-box > .textwidget
@@ -1077,6 +1080,7 @@ enowiny.pl##.widget.mnmd-widget.mnmd-widget-indexed-posts-c, .cat-6.post--vertic
 eostroleka.pl##DIV[style$="margin:0 3px 4px 0; overflow:hidden;"]
 eostroleka.pl##DIV[style$="width: 100%; margin: 8px auto; overflow: hidden;"]
 eostroleka.pl##DIV[style="margin-bottom:10px; margin-left:25px; float:left; width:300px; height:300px;"]
+eostroleka.pl##[id^="main_page-newB"], .loading-ajax-ads, [data-ads-priority], [data-ads-maxsizex], [data-ads-maxsizey], [data-ads-place], [data-ads-page], [data-ads-limit]
 epainfo.pl###custom_html-19, #custom_html-18
 epainfo.pl##.td_block_text_with_title
 epainfo.pl##.wpb_text_column
@@ -1440,6 +1444,7 @@ goleniowska.com##.modul_baner.modul, #section.golen-widget, .golen-widget
 goleniowska.com##[href^="https://goleniowska.com/linkout/"]
 goleniowska.com##[id^="golen-slider-"]
 golfnews.pl##[href^="https://golfnews.pl/do/"]
+golfpl.com##.footer-block-4, #secondary-right-sidebar
 gomoney.pl###aunit
 gomoney.pl###taw0
 goniec.net###gkContentTop > .box:nth-of-type(1)
@@ -2013,7 +2018,7 @@ leki.fora.pl##.trzContent
 lento.pl###a-show-boottom
 lento.pl###sidebar-promo
 leonclub.pl##.bg3.post
-lesko.info##.widget-header, #content > center > A > IMG, .widget_media_image.widget
+lesko.info##.widget-header, #content > center > A > IMG, .widget_media_image.widget, #content > center
 letsplej.pl,regionfan.pl,4trucks.pl,nie-spamuj.eu##.rekl
 lexlege.pl###right_reklama
 lexus-forum.pl##body > .forabg
@@ -2282,7 +2287,8 @@ mikrokontroler.pl,24legnica.pl,polonia-peterborough.uk,24legnica.pl,bieganieuskr
 milanos.pl#?#.post:-abp-contains(reklama)
 minecraft-list.pl##.smutnazabajpg_container.transparent_container, #a.pleaserinonoblokerino_display, div.gitjestgit_container, #news_popup, a.niepokolei_display
 minecraft.org.pl##.stone-module.well-sm.well:nth-of-type(4)
-minskmaz.com##.poster-1, .g-a-s
+minskmaz.com##.poster-1, .g-a-s, .lastest-news-posters
+minskmaz.com##.column-right > a[target="_blank"]
 mistrzowie.org###services_box
 mistrzowie.org##.clearfix.lbox.pic:nth-of-type(5)
 mistrzowie.org##[href*="utm_source=mistrzowie&utm_medium=banner&utm_campaign=pewexserwisy_mistrzowie"]
@@ -2801,7 +2807,6 @@ podlasie24.pl##.dark > td > .box2x1s, .megaBBox
 podlasie24.pl###bA1
 podlasie24.pl###bA66
 podlasie24.pl##HR
-polski-slownik.pl##[class^="spolecznosci-iframe"], .imaplayer
 podoslonami.pl##.a14s
 podrogach.pl###secondary > div:nth-of-type(1), #text-3, #secondary > div > A > IMG
 pogoda.dziennik.pl###idm140677357800800
@@ -2811,13 +2816,17 @@ pogonsportnet.pl##.kode-content > section.kode-pagesection:nth-of-type(1) > .con
 pojezierze.com.pl##[class^="pojez-panel-"],.slick-track, div.clr.pojez-widget.sidebar-box > A
 poki.pl##[class*="advertisement-"]
 poki.pl##[class^="Advertisement"]
+pol-nor.com###rek2
 polacywewloszech.com###text-16, #text-17, #text-19
+polemi.co.uk##.standard_adv_img, .standard_adv_link, .adv_standard_d, .avd_display_block, #dropin, #art_widget
+polemi.co.uk##[href^="/reklama/1/boks-reklamowy-"]
 police24.pl##.bannerheader, [class*="banner"] > font
 police24.pl##.class\=.\ > table > tbody > tr:nth-of-type(4)
 police24.pl##td > table > tbody > tr:nth-of-type(1) > td:nth-of-type(1), div.jm-module:nth-of-type(3) > .jm-module-in > .clearfix.jm-module-content > .custom
 poligonowewiesci.pl###content > .container > div.row > .text-center.col-xs-12
 polnocna.tv##A[href^="/ad/"] > IMG, #block-block-20 > .clearfix.block-inner
 poloniairlandia.pl##.td-header-style-5.td-header-wrap, #td_uid_7_5abf827b54b35
+polonia.nl##.fqx
 polsatnews.pl##.LM__popup
 polsatnews.pl##div[class="ad"]
 polscygracze.pl##.gridlove-sidebar > .LfUW8dL1Hl-widget.gridlove-box.widget
@@ -2828,6 +2837,7 @@ polskaniepodlegla.pl###section-id-1503913327338, #section-id-1530612923433
 polskaniepodlegla.pl###sppb-addon-1503648426950
 polskaniepodlegla.pl###sppb-addon-1511187487983
 polskatradycja.pl##.uk-grid > div[class^="uk-width-expand"] > div.uk-card:nth-of-type(2)
+polski-slownik.pl##[class^="spolecznosci-iframe"], .imaplayer
 polski-tenis.pl##.hidden-xs
 polskiautohandel.pl##.header-middle
 polskiautohandel.pl##.panel.widget-2
@@ -3002,7 +3012,7 @@ prudnik24.pl##.panel.first.widget-1, .panel.widget-3, .panel.widget-4
 przychodnia.pl##.prnetItem
 pszczoly.pl###zajPasieka
 pszczoly.pl##tr > .tresc_bez_wciecia > A > IMG
-pszczyna.tv,czechowice.tv,bielsko.tv,tychy.info,pless.pl,czecho.pl,bielsko.info##.blok-link-rotacyjny, .reklama-display-desktop
+pszczyna.tv,czechowice.tv,bielsko.tv,tychy.info,pless.pl,czecho.pl,bielsko.info##.blok-link-rotacyjny, .reklama-display-desktop, .skyscraper-start
 pudelek.tv,wp.tv,interaktywnie.com##[src^="http://adv.wp.pl"]
 pukawka.pl##.partnerzy
 pulskwidzyna.pl##.banToper, .modCbox, .advanced-slider.slllider, #polecamy, .lBoxFinSer > A
@@ -3035,7 +3045,7 @@ pzps.pl##.slider.shop-slider, .no-margin.slider
 q4.pl###\33 DIV, .info-box-bottom
 q4.pl##TD[bgcolor="#f0f0f0"]
 q4.pl##TD[valign="middle"]
-q4.pl,chinytolubie.pl,filmyfantastyczne.pl,dts24.pl,przemysl.info.pl,eluban.pl,wien.info,resellernews.pl,independenttrader.pl,scie24.pl,ogrodinfo.pl,zakliczyninfo.pl,kk24.pl,gieldykryptowalut.pl,odkryjbitcoin.pl,stacja7.pl,kryptoholik.pl,cashowsky.pl,historyk.eu,marihuanamedyczna.com,pcworld.pl,esanok.pl,lovekrakow.pl,swiatdronow.pl,glosgminny.pl,damitv.pl,przyjaznawarszawa.pl,ecoportal.com.pl,zd24.pl,historiasportu.info,wszczecinie.pl,forum-bron.pl,zielonydziennik.pl,mieszkaniectargowka.pl,centrumdruku3d.pl,bielski24.pl,applemobile.pl,sprawnypo40.pl,forum.dopalamy.com,cyfrowypolsatnews.pl,olsztyn.com.pl,wpolityce.pl,nasztomaszow.pl,bielskiedrogi.pl,prokapitalizm.pl,agrokapital.pl,wieliczkacity.pl,fronda.pl,krytykapolityczna.pl,zycieczestochowy.pl,aferyprawa.eu,radomnews.pl,miasto.koszalin.pl,echopowiatu.pl,24jgora.pl,elka.pl,tv28.pl,chojna24.pl,nasz-glos.com,zyciepabianic.pl,zawiercianskie.pl,wsus.pl,wronieckibazar.pl,vetopedia.pl,tustolica.pl,trawka.org,tarnobrzeskie.eu,stressfree.pl,sportslaski.pl,roztocze.net,portalhodowcy.pl,podkarpackahistoria.pl,ostrowiecnews.pl,odkryjpomorze.pl,obcasypodlasia.pl,naszwodzislaw.com,naszraciborz.pl,modelwork.pl,legalnybukmacher.com,korso.pl,jaw.pl,goralpoleca.pl,gieldaklasykow.pl,fresh-market.pl,elubaczow.com,dziennikzwiazkowy.com,cire.pl,cgm.pl,anywhere.pl,angolia.co.uk,cksport.pl,kociesprawy.pl,iknurow.pl,wcipy.pl,tarnowiak.pl,polacywewloszech.com,aktyw14.net,legionisci.com,opinieouczelniach.pl,tygodnikzamojski.pl,czasnadmorze.pl,goryonline.com,kibice.net,swiatogloszen.net.pl,wloclawek.info.pl,futbolfejs.pl,rdn.pl,gloskoninski.pl,strzelecopolski.pl,polskieradio.com,podajdalej.info.pl,belchatow.bai.pl,miastokolobrzeg.pl,stomil.olsztyn.pl,polskaniepodlegla.pl,tsk24.pl,wschodnik.pl,tvnfakty.pl,kronikatygodnia.pl,szkolasen.com,lowiczanin.info,urodaizdrowie.pl,forum-norwegia.pl,chillitorun.pl,kuriergarwolinski.pl,weseleforum.pl,inwestycje-rzeszow.pl,wirtualnygarwolin.pl,nowemiasto.com.pl,motofaktor.pl,strazacki.pl,bezdroza.pl,twojeradio.fm,wpr24.pl,sanatoria.com.pl,sadownictwo.com.pl,lubliniec.info,gwarek.com.pl,calisia.pl,dsw.doba.pl,laczynaspasja.pl,klubowa.pl,businesswomanlife.pl,krasnik24.pl,lubelska.tv,forum.haszysz.com,ipragapoludnie.pl,itvm.pl,comperia.pl,kawiarniany.pl,plportal.pl,kurierzamojski.pl,roosevelta81.pl,bham.pl,szczecinek.com,40ton.net,komputery-kalwaria.pl,mediasystem-tdi.pl,codziennikmlawski.pl,portalpszczelarski.pl,rzesport.pl,rutatour.pl,supernowosci24.pl,cyfrowaekonomia.pl,jazzarium.pl,czecho.pl,magazynvip.pl,wht.pl,gtasite.net,ciechanowinaczej.pl,wrzesnia.info.pl,zw.pl,reporterzy.info,lubiehrubie.pl,salaterka.pl,extraswiecie.pl,mojejaworzno.pl,pozytywniej.pl,open.fm,animeholik.pl,inthecage.pl,pfm.pl,kuchenny.com.pl,e-kolo.pl,lowcaburzwielun.pl.tl,glokalna.pl,igostyn.pl,ikalisz.pl,iostrowwlkp.pl,ijarocin.pl,ipleszew.pl,wspolnypowiat.pl,niepoddawajsie.pl,voltahorse.pl,etransport.pl,miastons.pl,czadrow24.pl,laskonline.pl,ototorun.pl,gdzietymrazem.pl,e-kursy-walut.pl,warszawiak.pl,gb.pl,sanok24.pl,tvregionalna24.pl,radiozamosc.pl,przewodnik-katolicki.pl,forum-oddluzanie.pl,systemyplatnosci.com,itwiz.pl,jaslo4u.pl,awangardafutbolu.pl,racingforum.pl,tenis.net.pl,zajefajna.com,galeriastron.pl,lubanski.eu,twojeglubczyce.pl,info.stargard.pl,chojnice.com,dzienniknowy.pl,webhostingtalk.pl,di.pl,nowytydzien.pl,biokurier.pl,spottedlublin.pl,miejscawewroclawiu.pl,infobrzeszcze.pl,infoskierniewice.pl,wio.waw.pl,blogtransportowy.pl,korsokolbuszowskie.pl,twojaslupca.pl,makowonline.pl,gs24.pl,radio.katowice.pl,telefonowal.pl,meczenazywo.pl,ustawmundial.weszlo.com,galeria-tajlandia.pl,oprocentowanielokat.pl,goal.pl,budujesz.info,mypolacy.nl,chceauto.pl,comparic.pl,inowroclaw.info.pl,webhelp.pl,nanarty.info,wylecz.to,przewodnikmp.pl,autoline.com.pl,fishing-test.pl,radio7.pl,estradaistudio.pl,zakupydladziecka.pl,livesound.pl,pomorskifutbol.pl,tkn24.pl,tucholanin.pl,uploaduj.com,dzisiajwgliwicach.pl,czyjnumerek.pl##A[target="_blank"] > IMG
+q4.pl,chinytolubie.pl,filmyfantastyczne.pl,dts24.pl,przemysl.info.pl,eluban.pl,wien.info,resellernews.pl,independenttrader.pl,scie24.pl,ogrodinfo.pl,zakliczyninfo.pl,kk24.pl,gieldykryptowalut.pl,odkryjbitcoin.pl,stacja7.pl,kryptoholik.pl,cashowsky.pl,historyk.eu,marihuanamedyczna.com,pcworld.pl,esanok.pl,lovekrakow.pl,swiatdronow.pl,glosgminny.pl,damitv.pl,przyjaznawarszawa.pl,ecoportal.com.pl,zd24.pl,historiasportu.info,wszczecinie.pl,forum-bron.pl,zielonydziennik.pl,mieszkaniectargowka.pl,centrumdruku3d.pl,bielski24.pl,applemobile.pl,sprawnypo40.pl,forum.dopalamy.com,cyfrowypolsatnews.pl,olsztyn.com.pl,wpolityce.pl,nasztomaszow.pl,bielskiedrogi.pl,prokapitalizm.pl,agrokapital.pl,wieliczkacity.pl,fronda.pl,krytykapolityczna.pl,zycieczestochowy.pl,aferyprawa.eu,radomnews.pl,miasto.koszalin.pl,echopowiatu.pl,24jgora.pl,elka.pl,tv28.pl,chojna24.pl,nasz-glos.com,zyciepabianic.pl,zawiercianskie.pl,wsus.pl,wronieckibazar.pl,vetopedia.pl,tustolica.pl,trawka.org,tarnobrzeskie.eu,stressfree.pl,sportslaski.pl,roztocze.net,portalhodowcy.pl,podkarpackahistoria.pl,ostrowiecnews.pl,odkryjpomorze.pl,obcasypodlasia.pl,naszwodzislaw.com,naszraciborz.pl,modelwork.pl,legalnybukmacher.com,korso.pl,jaw.pl,goralpoleca.pl,gieldaklasykow.pl,fresh-market.pl,elubaczow.com,dziennikzwiazkowy.com,cire.pl,cgm.pl,anywhere.pl,angolia.co.uk,cksport.pl,kociesprawy.pl,iknurow.pl,wcipy.pl,tarnowiak.pl,polacywewloszech.com,aktyw14.net,legionisci.com,opinieouczelniach.pl,tygodnikzamojski.pl,czasnadmorze.pl,goryonline.com,kibice.net,swiatogloszen.net.pl,wloclawek.info.pl,futbolfejs.pl,rdn.pl,gloskoninski.pl,strzelecopolski.pl,polskieradio.com,podajdalej.info.pl,belchatow.bai.pl,miastokolobrzeg.pl,stomil.olsztyn.pl,polskaniepodlegla.pl,tsk24.pl,wschodnik.pl,tvnfakty.pl,kronikatygodnia.pl,szkolasen.com,lowiczanin.info,urodaizdrowie.pl,forum-norwegia.pl,chillitorun.pl,kuriergarwolinski.pl,weseleforum.pl,inwestycje-rzeszow.pl,wirtualnygarwolin.pl,nowemiasto.com.pl,motofaktor.pl,strazacki.pl,bezdroza.pl,twojeradio.fm,wpr24.pl,sanatoria.com.pl,sadownictwo.com.pl,lubliniec.info,gwarek.com.pl,calisia.pl,dsw.doba.pl,laczynaspasja.pl,klubowa.pl,businesswomanlife.pl,krasnik24.pl,lubelska.tv,forum.haszysz.com,ipragapoludnie.pl,itvm.pl,comperia.pl,kawiarniany.pl,plportal.pl,kurierzamojski.pl,roosevelta81.pl,bham.pl,szczecinek.com,40ton.net,komputery-kalwaria.pl,mediasystem-tdi.pl,codziennikmlawski.pl,portalpszczelarski.pl,rzesport.pl,rutatour.pl,supernowosci24.pl,cyfrowaekonomia.pl,jazzarium.pl,czecho.pl,magazynvip.pl,wht.pl,gtasite.net,ciechanowinaczej.pl,wrzesnia.info.pl,zw.pl,reporterzy.info,lubiehrubie.pl,salaterka.pl,extraswiecie.pl,mojejaworzno.pl,pozytywniej.pl,open.fm,animeholik.pl,inthecage.pl,pfm.pl,kuchenny.com.pl,e-kolo.pl,lowcaburzwielun.pl.tl,glokalna.pl,igostyn.pl,ikalisz.pl,iostrowwlkp.pl,ijarocin.pl,ipleszew.pl,wspolnypowiat.pl,niepoddawajsie.pl,voltahorse.pl,etransport.pl,miastons.pl,czadrow24.pl,laskonline.pl,ototorun.pl,gdzietymrazem.pl,e-kursy-walut.pl,warszawiak.pl,gb.pl,sanok24.pl,tvregionalna24.pl,radiozamosc.pl,przewodnik-katolicki.pl,forum-oddluzanie.pl,systemyplatnosci.com,itwiz.pl,jaslo4u.pl,awangardafutbolu.pl,racingforum.pl,tenis.net.pl,zajefajna.com,galeriastron.pl,lubanski.eu,twojeglubczyce.pl,info.stargard.pl,chojnice.com,dzienniknowy.pl,webhostingtalk.pl,di.pl,nowytydzien.pl,biokurier.pl,spottedlublin.pl,miejscawewroclawiu.pl,infobrzeszcze.pl,infoskierniewice.pl,wio.waw.pl,blogtransportowy.pl,korsokolbuszowskie.pl,twojaslupca.pl,makowonline.pl,gs24.pl,radio.katowice.pl,telefonowal.pl,meczenazywo.pl,ustawmundial.weszlo.com,galeria-tajlandia.pl,oprocentowanielokat.pl,goal.pl,budujesz.info,mypolacy.nl,chceauto.pl,comparic.pl,inowroclaw.info.pl,webhelp.pl,nanarty.info,wylecz.to,przewodnikmp.pl,autoline.com.pl,fishing-test.pl,radio7.pl,estradaistudio.pl,zakupydladziecka.pl,livesound.pl,pomorskifutbol.pl,tkn24.pl,tucholanin.pl,uploaduj.com,dzisiajwgliwicach.pl,czyjnumerek.pl,pyrzyce.info##A[target="_blank"] > IMG
 racjonalista.tv,goniecpolski.nl###execphp-2
 racjonalista.tv###execphp-3
 radomsko24.pl##.space-bg.space
@@ -3572,9 +3582,7 @@ telewizjarepublika.pl##[id^="contentsystem-slide"]
 telewizjattm.pl##.banner-main-page
 telewizjazary.pl##.jeg_navbar, [style="text-align: center;"]
 telewizjazary.pl#?#.jeg_block_heading:-abp-has(>h3>span:-abp-contains(Reklama))
-telewizor.eu###block
-telewizor.eu###polecamy
-telewizor.eu##img[width="468"][height="60"]
+telewizor.eu###block, #polec, #polecamy, img[width="468"][height="60"]
 telewizor.pl###banner_top
 telix.pl##[id^="telix-"]
 telko.in##.box-partners, span[style^="font-size: 0.7em"]
@@ -3743,8 +3751,7 @@ tygodnikzamojski.pl##ul.banners
 tygodnik.szczytno.pl#?#p:-abp-contains(Reklama)
 tygodnikketrzynski.pl###text-53
 tygodniowa.pl###__mce_tmp
-tylkoastronomia.pl###block-block-16, #block-block-18
-tylkoastronomia.pl###block-block-16, .even.field-item > div
+tylkoastronomia.pl###block-block-16, #block-block-18, .even.field-item > div
 tylkotorun.pl###fsp_light, .artadv, .tf_w.tf_box.tb-column-inner
 tylkomedycyna.pl###block-block-19, #block-block-16, .even.field-item > div
 tylkonauka.pl##.even.field-item > div
@@ -4217,7 +4224,7 @@ zizako.pl###widget_shop6
 zlota7.pl##.ultp-image-block-opacity.ultp-image-block
 zlotowskie.pl##[id^="D1000"], div.l-row:nth-of-type(8) > div.l-box--33.l-box, div.l-container > div.l-row > .l-box--100.l-box, [id^="Gazeta370"], [id^="D300x250"], div.l-row > div.l-box--50.l-box, #D300x600, #verticalBannerGallery
 zlubaczowa.pl###Mod605, #Mod584, #Mod599
-zkaszub.info##.zkasz-widget.widget, #block-3, .amkad
+zkaszub.info##.zkasz-widget.widget, #block-3, .amkad, .zkasz-przed-trescia, .zkasz-tresc, .zkasz-w-tresci_2, .zkasz-po-tresci_4
 zlotoryjska.pl##div.noprint.pole-banerowe > A[target="_blank"] >IMG
 zmianynaziemi.pl###block-block-27, #block-block-19, #block-block-32, #block-block-16, .even.field-item > div
 zory.dlawas.pl##.in.fade.modal-backdrop
@@ -4646,6 +4653,7 @@ zywiecinfo.pl##[href*="/component/banners/click/"]
 ||redir.atmcdn.pl/scale/o2/tvn/web-content/m/p2/i/81c8727c62e800be708dbf37c4695dff/$image,domain=tvnwarszawa.tvn24.pl
 ||reklama-lowicz.pl^$image
 ||reklamawadowice24.pl^$image
+||reklama.pyrzyce.eu^
 ||reklamy.s3.amazonaws.com/bcg/$image
 ||reklamy.grupafarmacja.net^
 ||reklamy.naszraciborz.pl^
@@ -5276,6 +5284,7 @@ srkcast.com##[id^="table"]
 !
 !31#--------------------------WP Group element hide------------!
 abczdrowie.pl##[data-element="wide-placeholder"]
+autocentrum.pl,e.autokult.pl##body > div[class]:first-child:not([id])
 autokult.pl##.insert--top-offer.insert, .partner-area
 autokult.pl##[href^="http://corto.www.wp.pl/"]
 avent-ugrow.wp.pl##[class$="BgClick"]
@@ -5314,16 +5323,19 @@ ranking.abczdrowie.pl#?#div[class]:-abp-has(>div>iframe)
 wawalove.pl##.floating-ad.advertisement
 wawalove.pl##a[href="http://dajsygnal.pl/"]
 wawalove.pl,pytamy.pl,dzieci.pl##[id^="adv"]
+zywotziemniaka.wp.pl##.advertisement, .banner
 !
 !32#--------------------------WP element block------------!
 ||i.wp.pl/*/stg/wpjslib-nojq.js$script,domain=www.dobreprogramy.pl
 ||v.wpimg.pl/M*fxc*==$image,domain=sportowefakty.wp.pl
 !||wp.pl/b3RvQ2h1TVIzFCcBR0pAR3*DtBSkw=$script,domain=~pilot.wp.pl|~www.dobreprogramy.pl
+||lays-sm-2023.wpcdn.pl/img/banner_*.png$image
 ||wpkoszyk.wp.pl/api/koszyk$xmlhttprequest
 ||www.wp.pl/*.okazje-kokpit.chunk.js
 ||xml.enovatis.pl/mrdsl/json.php$xmlhttprequest,domain=turystyka.wp.pl
 !
 !33#--------------------------WP element hide------------!
+autocentrum.pl,autokult.pl,dobreprogramy.pl,fotoblogia.pl,gadzetomania.pl,genialne.pl,komorkomania.pl,polygamia.pl,pysznosci.pl,tech.wp.pl#?#[role="listitem"]:-abp-has(span:-abp-contains(REKLAMA))
 czat.wp.pl,infografika.wp.pl,dladzieci.pl,muzyka.wp.pl,niewiarygodne.pl,sportowybar.wp.pl,forum.o2.pl,topnews.wp.pl,ogloszenia.wp.pl##[id*="adv"]
 !film.wp.pl,turystyka.wp.pl,opinie.wp.pl,gry.wp.pl,tech.wp.pl,moto.wp.pl,kobieta.wp.pl,finanse.wp.pl,sportowefakty.wp.pl,wiadomosci.wp.pl,pudelek.pl,tv.wp.pl##* > DIV[style*="; overflow: hidden"]
 wp.pl##.wp-player > .adpause > .plchldr
@@ -5343,6 +5355,7 @@ pogoda.wp.pl##DIV.stamp + * + DIV[class]
 !pogoda.wp.pl##DIV[class]:first-child + * + DIV[class]
 pogoda.wp.pl##DIV[style="text-align: center;"] > DIV[class]:first-child
 sportowefakty.wp.pl##.image--lead + div:not([class])
+sportowefakty.wp.pl##.articleteaser:not([class$=" "])
 sportowefakty.wp.pl##main div[class*=" "]:empty:not(.btnmute):not(.volsliderbg):not([style]):not([id]):not([img]):not([src])
 sportowefakty.wp.pl,kobieta.wp.pl,moto.wp.pl,tech.wp.pl,gry.wp.pl,opinie.wp.pl,turystyka.wp.pl,pogoda.wp.pl,tv.wp.pl,finanse.wp.pl##* > DIV[style*="max-width: 100%;"]
 sportowefakty.wp.pl##.section__separator
@@ -5431,6 +5444,7 @@ www.money.pl##DIV[style$=" z-index: auto;"] > DIV[class]
 www.money.pl##P + DIV[style$="padding:10px 0"]
 www.money.pl##SCRIPT[src^="//money"] + DIV[class][style="text-align:center;"]
 www.money.pl#?#.article__content>div[class*=" "]:-abp-has(div>div>div:-abp-contains(REKLAMA))
+money.pl,pudelek.pl#?#[data-st-area="list-recommended4you-MainColumn"] > div > div:-abp-contains(REKLAMA)
 www.money.pl,moneyv.wp.pl###app > div[data-reactroot] > [class^="sc-"] + div[class]:not([class^="sc-"]):nth-of-type(6)
 money.pl,moneyv.wp.pl#?#div[class^="sc-"]:-abp-has(> img[src="https://i.wpimg.pl/O/56x45/i.wp.pl/a/i/stg/pkf/bg.png"])
 !
@@ -5561,7 +5575,7 @@ podgorze.pl,strajk.eu,busiarze.com.pl,naszglospoznanski.pl###text-16
 polskifr.fr##div.container > .row > .my-3.col-12
 porozmawiajmy.tv###text-29
 promocja.mielec.pl##.image-inside
-pyrzyce.info##div#sidebar-srodkowy:nth-of-type(9), #text-117, #text-147
+pyrzyce.info##div#sidebar-srodkowy:nth-of-type(9), #text-117, #text-147, .header-right
 radiofon.fm,wilanownews.pl###text-28
 rydzyna24.pl##[id^="rydzy-"]
 rydzyna24.pl#?#h2:-abp-contains(Reklama)

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 19 January 2024
+! Last modified: 22 January 2024
 ! Expires: 1 day
-! Version: 2024011901
+! Version: 2024012201
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2022 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024011901 aktualizacja: pt, 19 stycznia 2024, 20:31:00
+! v.2024012201 aktualizacja: pon, 22 stycznia 2024, 22:00:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -211,6 +211,7 @@ profil.wp.pl##+js(set, Object.prototype.loadAndRunBunch, noopFunc)
 kafeteria.pl,polygamia.pl,open.fm,pudelek.pl##+js(nostif, HubAPI, 3000)
 kafeteria.pl,polygamia.pl,open.fm,pudelek.pl##+js(aeld, message, t.origin===k)
 wp.pl##+js(no-setTimeout-if, /getComputedStyle[\s\S]*?style\.display="none"[\s\S]*?styleBlocked[\s\S]*?detected/)
+dom.wp.pl,kobieta.wp.pl,ksiazki.wp.pl,kuchnia.wp.pl,pogoda.wp.pl,turystyka.wp.pl,wiadomosci.wp.pl#?#[data-native-adv]:-abp-has(a>span:-abp-contains(REKLAMA)):upward(1)
 dom.wp.pl,facet.wp.pl,film.wp.pl,finanse.wp.pl,gry.wp.pl,gwiazdy.wp.pl,kobieta.wp.pl,ksiazki.wp.pl,kuchnia.wp.pl,moto.wp.pl,opinie.wp.pl,tech.wp.pl,teleshow.wp.pl,turystyka.wp.pl,wawalove.wp.pl,wiadomosci.wp.pl,wroclaw.wp.pl#?#td[data-reactid] > div[class] > div[class] > div[class*=" "] > div[class] > span:contains(/^TWOJE OKAZJE$/):upward(2)
 dom.wp.pl,facet.wp.pl,film.wp.pl,finanse.wp.pl,gry.wp.pl,gwiazdy.wp.pl,kobieta.wp.pl,ksiazki.wp.pl,kuchnia.wp.pl,moto.wp.pl,opinie.wp.pl,tech.wp.pl,teleshow.wp.pl,turystyka.wp.pl,wawalove.wp.pl,wiadomosci.wp.pl,wroclaw.wp.pl#?#div[class*=" "]:has(>div[class]:first-child:empty+img[src*="://v.wpimg.pl/"][alt]:empty)
 abczdrowie.pl,autokult.pl,echirurgia.pl,film.wp.pl,fotoblogia.pl,gadzetomania.pl,gry.wp.pl,horoskop.wp.pl,kobieta.wp.pl,komorkomania.pl,medycyna24.pl,money.pl,parenting.pl,pogoda.wp.pl,tech.wp.pl,tv.wp.pl,twojeip.wp.pl,wiadomosci.wp.pl,wideo.wp.pl,sportowefakty.wp.pl,fitness.wp.pl,wawalove.wp.pl,gwiazdy.wp.pl,teleshow.wp.pl,www.wp.pl##+js(aost, WP.prebid, onLoad)


### PR DESCRIPTION
**Reklamy / puste kontenery/napisy po reklamach :**

**1]** Grupa Wirtualna Polska :
fix #1525, fix #2497, fix #3951,fix #4037, fix #7533, fix #13818, 
f-i-x #18472, fix https://github.com/uBlockOrigin/uAssets/issues/12214 :
- na kilkunastu stronach ukrycie dolnych reklam/kontenerów w polecanych, głównie na podstronach/artykułach (jako uzupełnienie do uAssets bo ich filtry z `utm_` nie wyłapują wszystkich reklam/kontenerów  i dodatkowo się glitchują/nie działają w FF 115 ESR z włączoną flagą `:has`, przy okazji niektóre dodane przeze mnie wspierają też Adblocka) : `autocentrum.pl,autokult.pl,dobreprogramy.pl,dom.wp.pl,fotoblogia.pl,gadzetomania.pl,genialne.pl,kobieta.wp.pl,komorkomania.pl,ksiazki.wp.pl,kuchnia.wp.pl,money.pl,pogoda.wp.pl,polygamia.pl,pudelek.pl,pysznosci.pl,sportowefakty.wp.pl,tech.wp.pl,turystyka.wp.pl,wiadomosci.wp.pl` :
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1902064210 (Pt 4) 
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1902114803
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1902173520
fix https://github.com/uBlockOrigin/uAssets/issues/12214#issuecomment-1902257825 (B + C)
- przy okazji f-i-x https://github.com/MajkiIT/polish-ads-filter/issues/18472#issuecomment-1905385380 :
`zywotziemniaka.wp.pl` : reklamy na głównej i w artykuach
`e.autokult.pl` + `autocentrum.pl` - baner reklamowy na samej górze w nagłówku
-  drobne kosmetyczne poprawki :
`polski-slownik.pl` - przeniesienie filtra w odpowiednie miejsce wg. alfabetu
`tylkoastronomia.pl` - sklejenie 2 filtrów w 1 + usunięcie zduplikowanego selektora ID

**2]** Kilkanaście innych stron : 
fix #22262, fix #22263, fix #22264, fix #22265, fix #22266, 
fix #22267, fix #22268, fix #22269, fix #22270, fix #22271, 
fix #22279, fix #22280, fix #22281, fix #22282, fix #22282,
fix #22287, close #22278