### PR TITLE
Add another android browser with support for extensions

### DIFF
--- a/website/content/pl/docs/advanced/Jak-blokowac-reklamy-w-przegladarce-Yandex-na-Androidzie.md
+++ b/website/content/pl/docs/advanced/Jak-blokowac-reklamy-w-przegladarce-Yandex-na-Androidzie.md
@@ -14,6 +14,9 @@ tags:
 - adblocker
 - rozszerzenia
 - filtry
+- Firefox
+- lis
+- Edge
 date: 18 Nov 2018
 ---
 
@@ -29,7 +32,16 @@ Po zainstalowaniu [Kiwi Browser](https://play.google.com/store/apps/details?id=c
 2. Wybierz filtry, jakie chcesz. A jeśli 2 polskie ci nie wystarczają, to wejdź na [majkiit.github.io/polish-ads-filter](https://majkiit.github.io/polish-ads-filter/) i zasubskrybuj dodatkowe.
 3. Gotowe!
 
-## C) ![Webview]Dowolna przeglądarka + ![AG]AdGuard
+## C) ![Edge Canary]Microsoft Edge Canary + ![uBO]uBlock Origin
+Po zainstalowaniu [Edge Canary](https://play.google.com/store/apps/details?id=com.microsoft.emmx.canary) wystarczy wykonać parę kroków:
+1. Wejdź na `edge://flags`, a następnie wpisz `Android Extensions` w pole wyszukiwania, dotknij na `Default` i przestaw na `Enabled`.
+2. Dotknij `Uruchom ponownie`.
+3. Dotknij 3 paski, następnie przewiń maksymalnie w prawo i wybierz `Całe menu`.
+4. Dotknij `Extensions => uBlock Origin => Get => Dodaj`.
+5. Wybierz filtry, jakie chcesz. A jeśli 2 polskie ci nie wystarczają, to wejdź na [majkiit.github.io/polish-ads-filter](https://majkiit.github.io/polish-ads-filter/) i zasubskrybuj dodatkowe.
+6. Gotowe!
+
+## D) ![Webview]Dowolna przeglądarka + ![AG]AdGuard
 1. Wejdź na https://adguard.com/pl/welcome.html i kliknij **Pobierz**.
 2. Wejdź do powiadomień i dotknij pobrany plik apk, a następnie dotknij **zainstaluj**, a jeżeli dostaniesz informację o instalowaniu z nieznanego źródła, to skorzystaj z poradnika dostępnego na [android.com.pl](https://android.com.pl/porady/250018-aplikacje-z-nieznanych-zrodel/).
 3. Uruchom AdGuard i dotknij **Akceptuj**.
@@ -37,10 +49,11 @@ Po zainstalowaniu [Kiwi Browser](https://play.google.com/store/apps/details?id=c
 5. Dotknij `3 kropki => ustawienia => blokowanie treści => filtry` i wybierz to, co chcesz, zwracając szczególną uwagę na specyficzne językowe.
 6. Gotowe!
 
-[Firefox]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/73.0.2/firefox/firefox_24x24.png "Mozilla Firefox"
+[Firefox]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/74.1.0/firefox/firefox_24x24.png "Mozilla Firefox"
 [Kiwi]: /images/kiwi_24.png "Kiwi Browser"
 [Lemur]: /images/lemur_24.png "Lemur Browser"
-[Webview]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/73.0.2/android-webview/android-webview_24x24.png
+[Edge Canary]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/74.1.0/edge-canary/edge-canary_24x24.png
+[Webview]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/74.1.0/android-webview/android-webview_24x24.png
 
 [uBO]: /images/uBO_24.png
 [AG]: /images/AdGuard_logo_24.png


### PR DESCRIPTION
Microsoft zdecydował się dołączyć do zabawy z rozszerzeniami na Androidzie :smile:. Niestety póki co wybór jest ograniczony zupełnie jak to kiedyś Mozilla zrobiła. Do wyboru jest uBO, Dark Reader i coś o nazwie Global Speed.