### PR TITLE
Update `adblock*.txt`

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 24 February 2024
+! Last modified: 28 February 2024
 ! Expires: 1 day
-! Version: 2024022401
+! Version: 2024022800
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2024 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024022401 aktualizacja: sob, 24 lutego 2024, 05:10:00
+! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:13
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -232,7 +232,7 @@ pl,com###top_advertisement
 pl/popup.js|$script
 popkiller.pl,tygodnikpodhalanski.pl,cnc.info.pl##[class*="reklamy"]
 ~allegro.pl,~dipp.pl,~motobanda.pl,pl##.advert
-~astrosalus.pl,~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,~uwaga.tvn.pl,anglia.today,dbnao.net,pl,~selectshop.pl##.ad
+~astrosalus.pl,~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~uwaga.tvn.pl,anglia.today,dbnao.net,pl,~selectshop.pl##.ad
 ~akademikpersonel.org,~avclub.gr,~csbydgoszcz.pl,~forodecostarica.com##[id^="ad_global"]
 ~esanok.pl,~brzozow24.pl,~bukowsko24.pl,~jaslo24.pl,~rzeszow24.pl,~strzyzow24.pl,~tvpodkarpacie.pl,~ustrzyki24.pl,~zagorz24.pl,~zarszyn24.pl,~tvkrosno.pl,pl###top-reklama
 ~file-upload.com,~facebook.com,~pi.hole,~finn.no##[id^="ads_"]
@@ -243,24 +243,24 @@ popkiller.pl,tygodnikpodhalanski.pl,cnc.info.pl##[class*="reklamy"]
 ~kakto.pl,~agatameble.pl,~ccc.eu,~redcoon.pl##a[href*="/ad/click/"]
 ~tatromaniak.pl,~lowcygier.pl,pl##a[href*="://converti.se/click/"]
 ~m3esolutions.com,~sloworegionu.pl,~4active.eu,~valida.pl,~foodprint.pl,~roztoczanskipn.pl##.banneritem
-~biblio.com,~milionczesci.pl,~dizibox.com,~2dehands.be,~ru,~ua,~www.pudelek.pl,~btdb.eu,~ewybory.eu##[id^="adv-"]:not(#adv-settings)
+~biblio.com,~milionczesci.pl,~dizibox.com,~2dehands.be,~btdb.eu,~ewybory.eu,~pudelek.pl,~ru,~ua,~me##[id^="adv-"]:not(#adv-settings):not(.adv-player-container)
 ~24jgora.pl,~24wroclaw.pl,~bbfan.pl,~bp24.pl,~e-sochaczew.pl,~egarwolin.pl,~egorzow.pl,~ekspresjaroslawski.pl,~goral.info.pl,~iochota.pl,~iotwock.info,~iskierniewice.pl,~izyrardow.pl,~jaworzno.biz,~kartuzy.info,~koscierski.info,~kurierbytowski.com.pl,~kurierpodlaski.pl,~lowicz24.eu,~mylomza.pl,~nswiecie.pl,~ool.ru,~pulsgdanska.pl,~skarzyski.eu,~szydlowiecki.eu,~tulegnica.pl,~turyki.pl,~zambrow.org##[class*="box-advert"]
 ~plonskwsieci.pl##.a-d-v-i
 ~otodom.pl,~przegladsportowy.pl,~wpolityce.pl,~hardcorowo.pl,~filmweb.pl,~fakro.pl,~dziennikwschodni.pl,~galilu.pl,~uwaga.tvn.pl,pl,~meczyki.pl,~milmag.pl##[class^="ad-"]
-~przegladsportowy.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##[id^="crt-"]
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl###advertisments
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl###pixad-box
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl###widget-shop
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##.adform-slot
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##.adsense
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##.linkSponsorowany
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##.ppa-slot
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##.sliderads
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl##.widget-ads-content
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl,~natemat.pl##.onnetwork-video
-~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,pl,~polsatnews.pl,~polsatsport.pl,~twojapogoda.pl,~comperia.pl,~wp.pl,~dobreprogramy.pl,~motobanda.pl,~lubartow24.pl##.ads
-~przegladsportowy.pl,~playpuls.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,~gry-online.pl,~tv6.com.pl,~trojmiasto.pl,~otomoto.pl,~dziennikwschodni.pl,~obalamyglupote.pl,pl,~pornohd.pl,~polskieszlaki.pl,~poczta.interia.pl,~comperia.pl,~filmweb.pl,~semtalk.pl,~eurogamer.pl,~mapa-turystyczna.pl,~otodom.pl,~ferrarikatowice.pl,~tvp.pl,~sekurak.pl,~naswieczniku-blog.pl,~duathlonradwanice.pl,~profitechnika.pl,~halowies.pl,~sadnowoczesny.pl,~warzywaiowoce.pl,~elita-magazyn.pl,~santander.pl,~mediaexpert.pl,~sadnowoczesny.pl,~warzywaiowoce.pl,~elita-magazyn.pl,~tygodnik-rolniczy.pl,~wiadomoscikosmetyczne.pl,~wiadomoscihandlowe.pl,~topagrar.pl##[class$="-ads"]
-!~przegladsportowy.pl,~playpuls.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~vod.pl,~gry-online.pl,~tv6.com.pl,~trojmiasto.pl,~otomoto.pl,~medonet.pl,pl##[class*="cg-template"]
+~przegladsportowy.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##[id^="crt-"]
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl###advertisments
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl###pixad-box
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl###widget-shop
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##.adform-slot
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##.adsense
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##.linkSponsorowany
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##.ppa-slot
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##.sliderads
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl##.widget-ads-content
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl,~natemat.pl##.onnetwork-video
+~przegladsportowy.pl,~medonet.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,pl,~polsatnews.pl,~polsatsport.pl,~twojapogoda.pl,~comperia.pl,~wp.pl,~dobreprogramy.pl,~motobanda.pl,~lubartow24.pl##.ads
+~auto-swiat.pl,~businessinsider.com.pl,~comperia.pl,~duathlonradwanice.pl,~dziennikwschodni.pl,~elita-magazyn.pl,~elita-magazyn.pl,~eurogamer.pl,~fakt.pl,~ferrarikatowice.pl,~filmweb.pl,~forbes.pl,~franczyzawhandlu.pl,~gry-online.pl,~halowies.pl,~komputerswiat.pl,~mapa-turystyczna.pl,~mediaexpert.pl,~naswieczniku-blog.pl,~noizz.pl,~obalamyglupote.pl,~onet.pl,~otodom.pl,~otomoto.pl,~playpuls.pl,~plejada.pl,~poczta.interia.pl,~polskieszlaki.pl,~pornohd.pl,~profitechnika.pl,~przegladsportowy.pl,~sadnowoczesny.pl,~sadnowoczesny.pl,~santander.pl,~sekurak.pl,~semtalk.pl,~topagrar.pl,~trojmiasto.pl,~tv6.com.pl,~tvp.pl,~tygodnik-rolniczy.pl,~warzywaiowoce.pl,~warzywaiowoce.pl,~wiadomoscihandlowe.pl,~wiadomoscikosmetyczne.pl,pl##[class$="-ads"]
+!~przegladsportowy.pl,~playpuls.pl,~fakt.pl,~forbes.pl,~auto-swiat.pl,~noizz.pl,~plejada.pl,~businessinsider.com.pl,~komputerswiat.pl,~onet.pl,~gry-online.pl,~tv6.com.pl,~trojmiasto.pl,~otomoto.pl,~medonet.pl,pl##[class*="cg-template"]
 ~przelewy24.pl,~allegro.pl,~zaq2.pl,~docer.pl,~dpd.com.pl,~scp-wiki.net.pl,~swiat-magii.pl,~portable.info.pl,pl##[id*="_ad-container"]
 ~przelewy24.pl,~allegro.pl,~zaq2.pl,~docer.pl,~dpd.com.pl,~scp-wiki.net.pl,~swiat-magii.pl,~portable.info.pl,pl##[id*="-ad-container"]
 ~przelewy24.pl,~allegro.pl,~zaq2.pl,~docer.pl,~dpd.com.pl,~scp-wiki.net.pl,~swiat-magii.pl,~portable.info.pl,pl##[id^="ad-container"]

--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -1311,6 +1311,8 @@ fragrantica.pl##[id^="\35"]
 franchising.pl###right, .imgBnr
 franchising.pl##[id^="scrAd"]
 francuskie.pl##.pem-caption-below.pem-caption, .franc-w-tresci, .franc-jacek-w-tresci
+franczyzawhandlu.pl##.top
+franczyzawhandlu.pl##div[class^="position_"][class$="top"]
 fronda.pl###ecoeconomy
 fronda.pl##.selfpromotion-ticker.pull-left
 fronda.pl##.small-info, .text-center.fixed-336.content

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 12 March 2023
+! Last modified: 28 Febuary 2024
 ! Expires: 1 day
-! Version: 2023021201
+! Version: 2024022800
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2023 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2023021201 aktualizacja: nie, 12 marca 2023, 22:56:00
+! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:17
 !
 !
 ! alltube.tv
@@ -251,8 +251,6 @@ alefunny.pl##.modal-open:style(overflow: auto !important; padding-right: 0px !im
 autokult.pl,gadzetomania.pl,komorkomania.pl,wp.pl##.modal__body-adblock
 dziwnekomiksy.pl##body>*:style(filter: blur(0px) !important;)
 !
-! Rules after Adblock
-vod.pl##.infoCloud:style(position: absolute!important; left: -3000px!important;)
 !
 ! Rules with conditions
 !#if (adguard_ext_firefox)

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -14,7 +14,7 @@
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
 ! Redundant Checker >> https://www.certyficate.it/redundant_checker/redundantRuleChecker.html
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
-! Copyright © 2023 Certyficate IT
+! Copyright © 2024 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
 ! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:17
 !

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -14,7 +14,7 @@
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
 ! Redundant Checker >> https://www.certyficate.it/redundant_checker/redundantRuleChecker.html
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
-! Copyright © 2022 Certyficate IT
+! Copyright © 2024 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
 ! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:23
 !

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,9 +6,9 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 26 January 2024
+! Last modified: 28 Febuary 2024
 ! Expires: 1 day
-! Version: 2024012601
+! Version: 2024022800
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -16,7 +16,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2022 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024012401 aktualizacja: pt, 26 stycznia 2024, 20:00:00
+! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:23
 !
 !
 !--------------------------Rules only to uBlock-------------!
@@ -269,8 +269,8 @@ streamin.to##+js(noeval-if, RTCPeerConnection)
 ! Popupy https://github.com/MajkiIT/polish-ads-filter/issues/2478
 ||go.onclasrv.com/apu.php$important,redirect=noop.js,script
 !
-! reklama po prawej np. na pclab.pl,onet.pl,businessinsider.com.pl,noizz.pl,komputerswiat.pl,plejada.pl
-auto-swiat.pl,businessinsider.com.pl,komputerswiat.pl,noizz.pl,onet.pl,pclab.pl,plejada.pl,vod.pl###nitro-block:style(position: absolute !important; left: -3000px !important;)
+! reklama po prawej np. na pclab.pl, onet.pl, businessinsider.com.pl, noizz.pl, komputerswiat.pl, plejada.pl
+auto-swiat.pl,businessinsider.com.pl,komputerswiat.pl,noizz.pl,onet.pl,pclab.pl,plejada.pl###nitro-block:style(position: absolute !important; left: -3000px !important;)
 !
 ! blokowanie gemius
 !||onet.hit.gemius.pl/fpdata.js$script,important
@@ -292,9 +292,6 @@ dvbtmap.eu###leftCol2:style(top: 51px !important;)
 ! tko.pl
 tko.pl##.pum-open:style(overflow: auto !important;)
 tko.pl##.pum[data-popmake*="uczelnia"]
-!
-!
-!
 !
 ! anyfiles.pl
 anyfiles.pl##+js(aopr, launchOpenWindow)
@@ -586,7 +583,9 @@ tekstowo.pl#$#.teledysk { flex: 0 0 100% !important; max-width: 100% !important;
 meczyki.pl##:not(.onnetwork-banner) > .placeholder:not(.onnetwork-banner):style(height: 0 !important; min-height: 0 !important;)
 !
 ! uBlock-user
-napiprojekt.pl##+js(insert-iframe, 1, honeypot, https://www.napiprojekt.pl/napisy-42731-Ostatni-U-Boot-(1993), width: 1px !important; height: 1px !important; position: absolute !important; left: -3000px !important)
+!napiprojekt.pl##+js(insert-iframe, 1, honeypot, https://www.napiprojekt.pl/napisy-42731-Ostatni-U-Boot-(1993), width: 1px !important; height: 1px !important; position: absolute !important; left: -3000px !important)
+napiprojekt.pl##+js(ape, body #catalgForm, iframe, src, https://www.napiprojekt.pl/napisy-42731-Ostatni-U-Boot-(1993))
+napiprojekt.pl##body #catalgForm iframe[src*="U-Boot"]
 ppe.pl###hot-slides-wrapper #hot_0, #hot-slider #m_hot_0
 ppe.pl##+js(ac, active, #m_hot_1)
 ppe.pl##+js(ac, box_active, #hot_1)


### PR DESCRIPTION
- usunięcie `vod.pl` z sekcji pamiętających, gdy portal był w rękach TVP/Onet.
- fix #22331
- fix #22327
- uaktualnienie https://github.com/MajkiIT/polish-ads-filter/issues/17418#issuecomment-724532833 / https://github.com/MajkiIT/polish-ads-filter/issues/17611 (`ii`/`insert-iframe` stało się przestarzałe)