### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 28 June 2024
+! Last modified: 22 July 2024
 ! Expires: 1 day
-! Version: 2024062801
+! Version: 2024072201
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2024 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024062801 aktualizacja: ptk, 28 czerwca 2024, 12:05:00
+! v.2024062801 aktualizacja: pon, 22 lipca 2024, 19:45:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -5820,6 +5820,7 @@ avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,magazyn-
 @@||googletagmanager.com^$script,domain=www.aptekarska.pl|aptekarski.com
 @@||google-analytics.com^$domain=www.aptekarska.pl|aptekarski.com
 @@||www.googletagmanager.com/gtm.js$script,domain=geselle.pl
+@@||www.cloudflare.com/cdn-cgi/trace$domain=plus.pl|polsatbox.pl
 !
 !50#--------------------------Video Players------------!
 ||vidoza.net/dl?op=view&*adb=$xmlhttprequest

--- a/polish-pihole-filters/hostfile.txt
+++ b/polish-pihole-filters/hostfile.txt
@@ -248,7 +248,7 @@ back.marketing
 behavioralengine.com
 caringcast.com
 cassini.efigence.com
-cdn.cookielaw.org
+#cdn.cookielaw.org
 clickcounters.com
 clickmatic.pl
 clickmeter.com

--- a/polish-pihole-filters/hostfile.txt
+++ b/polish-pihole-filters/hostfile.txt
@@ -207,7 +207,7 @@
 0.0.0.0 dronerc.it
 0.0.0.0 edujikim.com
 0.0.0.0 fabioluciani.com
-0.0.0.0 userload.co/maroc.js$script
+# 0.0.0.0 userload.co/maroc.js$script
 0.0.0.0 0x01n2ptpuz3.com
 0.0.0.0 www.mp3zik.net
 0.0.0.0 pinvazo.com
@@ -236,97 +236,97 @@
 0.0.0.0 pralkosuszarka-1936126.online
 0.0.0.0 mito-med.pl
 0.0.0.0 mito-pharma.pl
-0daib.pl
-abtshield.com
-adkontekst.pl
-adkontekst.pl
-adnxs.com
-api.useinsider.com
-asmsalesforce.pl
-audienceinsights.net
-back.marketing
-behavioralengine.com
-caringcast.com
-cassini.efigence.com
-#cdn.cookielaw.org
-clickcounters.com
-clickmatic.pl
-clickmeter.com
-clickserve.dartsearch.net
-clk.leadexpert.pl
-clk.tradedoubler.com
-coin-hive.com
-connect-lb.islay.tech
-consent.cookiebot.com
-cookies.neuca24.pl
-counter.hitslink.com
-daib.pl
-darmowylicznik.pl
-devhub.pl
-dot.wp.pl
-eu.ekatox.com
-gcontent.services.tvn.pl
-histats.com
-hit-pool.upscore.com
-hit.gemius.pl
-hit.platform.streamextension.com
-hitslink.interia.com.pl
-int.sitestat.com
-intrack.pl
-iwa3.hit.interia.pl
-kapi.dev
-kariera-polecamy.neuca.pl
-legenhit.com
-ma.wp.pl
-mautic.sfanews.pl
-meetrics.net
-mis.em.nscontext.eu
-mobiklivestmox.pl
-naanalle.pl
-netmng.com
-nextclick.pl
-nsaudience.pl
-p.typekit.net
-plugin.management
-privacy.polskapress.pl
-ps.polt.pl
-px.leadexpert.pl
-quantserve.com
-revsci.net
-rt.inistrack.net
-salesbee.pl
-salesbeehive.com
-smartclick.pl
-smpl.hit.ppdb.pl
-snrbox.com
-snrcdn.net
-stat.4u.pl
-stat.dziennik.pl
-stat.onestat.com
-stat.pl
-stat24.com
-statcounter.com
-static.chartbeat.com
-stats-srv.rp.pl
-stats.aptelink.pl
-stats.asp24.pl
-stats.goldenline.pl
-stats.landingi.com
-stg.wp.pl$script
-sylaba.net
-tealium.hs.llnwd.net
-track.buybox.click
-track.reinvigorate.net
-track.trojmiasto.pl
-tracker.skp.mbank.pl
-tracker.twenga.pl
-tracking.affiliate44.com.pl
-trackly.eu
-traq.li
-unknow.now.sh
-ut.o2.pl
-vendimob.pl
-x.sare25.com
-ymetrica.com
-allepharm.com
-trichomist.store
+0.0.0.0 0daib.pl
+0.0.0.0 abtshield.com
+0.0.0.0 adkontekst.pl
+0.0.0.0 adkontekst.pl
+0.0.0.0 adnxs.com
+0.0.0.0 api.useinsider.com
+0.0.0.0 asmsalesforce.pl
+0.0.0.0 audienceinsights.net
+0.0.0.0 back.marketing
+0.0.0.0 behavioralengine.com
+0.0.0.0 caringcast.com
+0.0.0.0 cassini.efigence.com
+# 0.0.0.0 cdn.cookielaw.org
+0.0.0.0 clickcounters.com
+0.0.0.0 clickmatic.pl
+0.0.0.0 clickmeter.com
+0.0.0.0 clickserve.dartsearch.net
+0.0.0.0 clk.leadexpert.pl
+0.0.0.0 clk.tradedoubler.com
+0.0.0.0 coin-hive.com
+0.0.0.0 connect-lb.islay.tech
+0.0.0.0 consent.cookiebot.com
+0.0.0.0 cookies.neuca24.pl
+0.0.0.0 counter.hitslink.com
+0.0.0.0 daib.pl
+0.0.0.0 darmowylicznik.pl
+0.0.0.0 devhub.pl
+0.0.0.0 dot.wp.pl
+0.0.0.0 eu.ekatox.com
+0.0.0.0 gcontent.services.tvn.pl
+0.0.0.0 histats.com
+0.0.0.0 hit-pool.upscore.com
+0.0.0.0 hit.gemius.pl
+0.0.0.0 hit.platform.streamextension.com
+0.0.0.0 hitslink.interia.com.pl
+0.0.0.0 int.sitestat.com
+0.0.0.0 intrack.pl
+0.0.0.0 iwa3.hit.interia.pl
+0.0.0.0 kapi.dev
+0.0.0.0 kariera-polecamy.neuca.pl
+0.0.0.0 legenhit.com
+0.0.0.0 ma.wp.pl
+0.0.0.0 mautic.sfanews.pl
+0.0.0.0 meetrics.net
+0.0.0.0 mis.em.nscontext.eu
+0.0.0.0 mobiklivestmox.pl
+0.0.0.0 naanalle.pl
+0.0.0.0 netmng.com
+0.0.0.0 nextclick.pl
+0.0.0.0 nsaudience.pl
+0.0.0.0 p.typekit.net
+0.0.0.0 plugin.management
+0.0.0.0 privacy.polskapress.pl
+0.0.0.0 ps.polt.pl
+0.0.0.0 px.leadexpert.pl
+0.0.0.0 quantserve.com
+0.0.0.0 revsci.net
+0.0.0.0 rt.inistrack.net
+0.0.0.0 salesbee.pl
+0.0.0.0 salesbeehive.com
+0.0.0.0 smartclick.pl
+0.0.0.0 smpl.hit.ppdb.pl
+0.0.0.0 snrbox.com
+0.0.0.0 snrcdn.net
+0.0.0.0 stat.4u.pl
+0.0.0.0 stat.dziennik.pl
+0.0.0.0 stat.onestat.com
+0.0.0.0 stat.pl
+0.0.0.0 stat24.com
+0.0.0.0 statcounter.com
+0.0.0.0 static.chartbeat.com
+0.0.0.0 stats-srv.rp.pl
+0.0.0.0 stats.aptelink.pl
+0.0.0.0 stats.asp24.pl
+0.0.0.0 stats.goldenline.pl
+0.0.0.0 stats.landingi.com
+# 0.0.0.0 stg.wp.pl$script
+0.0.0.0 sylaba.net
+0.0.0.0 tealium.hs.llnwd.net
+0.0.0.0 track.buybox.click
+0.0.0.0 track.reinvigorate.net
+0.0.0.0 track.trojmiasto.pl
+0.0.0.0 tracker.skp.mbank.pl
+0.0.0.0 tracker.twenga.pl
+0.0.0.0 tracking.affiliate44.com.pl
+0.0.0.0 trackly.eu
+0.0.0.0 traq.li
+0.0.0.0 unknow.now.sh
+0.0.0.0 ut.o2.pl
+0.0.0.0 vendimob.pl
+0.0.0.0 x.sare25.com
+0.0.0.0 ymetrica.com
+0.0.0.0 allepharm.com
+0.0.0.0 trichomist.store

--- a/polish-pihole-filters/hostfile.txt
+++ b/polish-pihole-filters/hostfile.txt
@@ -1,4 +1,4 @@
-#202307280303
+#202407220001
 # Polish filters for Pi hole
 # Collaborators: xxcriticxx, MajkiIT
 # Homepage: https://www.certyficate.it/


### PR DESCRIPTION
zamrożony formularz zgody aktualizacji umowy: https://linkon.plus.pl/offer/# - bez dopuszczenia nie ma białej ramki na hasło np. NIP lub białej ramki, że odrzuciliśmy lub zaakceptowaliśmy aneks (opcjonalnie informacji, że link wygasł lub jest niepoprawny np. literówka przy przepisywaniu z SMS-a/mejla).

Przy okazji sprawdzamy czy plik hostfile.txt zostanie cofnięty przez bota do poprzedniej wersji - dezaktywowałem w nim linie opisywaną w #22365 / #22463 (#22462) i dziwne blokowanie skryptów po ścieżce:
> `0.0.0.0 stg.wp.pl$script` / `0.0.0.0 userload.co/maroc.js$script` (to chyba nie działa nawet z AdGuard Home).

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
