### PR TITLE
Update `\/polish-adblock-filters\/.*\.(js|txt)`

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -9,7 +9,7 @@
 !   Patronite ==> https://patronite.pl/polskiefiltry
 ! Last modified: 29 January 2025
 ! Expires: 1 day
-! Version: 2025012901
+! Version: 2025012902
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2025 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2025012901 aktualizacja: sr, 29 stycznia 2025, 15:35:00
+! v.2025012902 aktualizacja: sr, 29 stycznia 2025, 17:05:00
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -1277,14 +1277,12 @@ forum.gram.pl###top_1, #bottom_1, #inside_1_wide
 forum.juvepoland.com###webfl
 forum.kodiwpigulce.pl##.wrapper > center
 forum.kodiwpigulce.pl##DIV[onclick="MyAdvertisements.do_click(1);"]
-forum.komputerswiat.pl,forumrowerowe.org,katalogi.pl,forum-sportu.pl,kfd.pl###post_id_
+forumrowerowe.org,katalogi.pl,forum-sportu.pl,kfd.pl###post_id_
 forum.nissanklub.pl##[class^="iParts_Ad"]
 forum.optymalizacja.com##.ipsBox.ipsWidget_vertical.ipsWidget
 forum.optymalizacja.com##[href$="utm_medium=banner"]
 forum.optymalizacja.com###ipsLayout_mainArea > .ipsSpacer_half.ipsSpacer_both
 forum.optymalizacja.com##form > .ipsSpacer_half.ipsSpacer_both > .ipsList_noSpacing.ipsList_reset.ipsType_center.ipsList_inline
-forum.pcformat.pl##.classic.post:not([style]):not([id])
-forum.pclab.pl###messageHook
 forumdermatologiczne.pl,forumginekologiczne.pl,forumkardiologiczne.pl,forumneurologiczne.pl,forumonkologiczne.pl,forumpediatryczne.pl,forumpsychiatryczne.pl,forumstomatologiczne.pl,fozik.pl,laryngo.pl##.ads-font, [class*="-add"], [class*="_add"], .mx-auto[style], .smplus\:mx-auto[style], .mx-auto.overflow-hidden
 forumpps.pl###sp_right > div.sp_block_section:nth-of-type(3)
 forumpps.pl##div.sp_block_section:nth-of-type(7)
@@ -2718,12 +2716,6 @@ patriot24.net##[style="display: block; width: 750px; height: 200px; margin: 0px 
 pccentre.pl##.box_orange.box.menu_r_hp:nth-of-type(5)
 pcformat.pl###ad_dol_srodek
 pch24.pl###baner926
-pclab.pl###a011
-pclab.pl###b028
-pclab.pl###spon_left
-pclab.pl###spon_right
-pclab.pl##A[href^="http://click.plista.com/pets/"]
-pclab.pl##[href^="http://csr.onet.pl/eclk/clk"]
 pcworld.pl###WhitepaperModule
 pcworld.pl###box_deal, .promo-frame
 pcworld.pl###newsmore408558 > .row:nth-of-type(2)
@@ -4645,9 +4637,6 @@ zywiecinfo.pl##[href*="/component/banners/click/"]
 ||partnerzyapi.ceneo.pl^$script
 ||partner.rankomat.pl/tracking/
 ||pasaz.goryonline.com/?k=$subdocument
-||pclab.pl/img/extra/$image,domain=pclab.pl
-||pclab.pl/img/special/*.jpg
-||pclab.pl/partners/$image,subdocument,domain=pclab.pl
 ||pfhb.pl/fileadmin/user_upload/baner_strona_glowna/$image
 ||picsrv.fora.pl/cdn/tri*trizer
 ||pilkanozna.pl/images/r-gol/$image

--- a/polish-adblock-filters/adblock_adguard.txt
+++ b/polish-adblock-filters/adblock_adguard.txt
@@ -6,30 +6,18 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 28 Febuary 2024
+! Last modified: 29 January 2025
 ! Expires: 1 day
-! Version: 2024022800
+! Version: 2025012902
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
 ! Redundant Checker >> https://www.certyficate.it/redundant_checker/redundantRuleChecker.html
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
-! Copyright © 2024 Certyficate IT
+! Copyright © 2025 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:17
+! v.2025012902 aktualizacja: sr, 29 stycznia 2025, 17:05:00
 !
-!
-! alltube.tv
-! Ominięcie czekania
-alltube.tv###please-wait-container
-alltube.tv#$##iframe-container { display: block !important; }
-!
-!
-! www.efilmy.tv
-! Ominięcie przycisku "Close Ad and Watch as Free User"
-efilmy.tv###hideOnClick
-efilmy.tv#$##playerVidzer { display: block !important; }
-efilmy.tv###step1
 !
 ! gahe.pl
 ! Ominięcie czekania

--- a/polish-adblock-filters/adblock_test.txt
+++ b/polish-adblock-filters/adblock_test.txt
@@ -15,6 +15,3 @@
 ! v.2021012001 aktualizacja: sr, 20 stycznia 2021,06:30:00
 !
 !
-||i.wp.pl^$image,domain=wp.pl
-||sportowefakty.wp.pl/*CWsTMm4zPDEJax*=$script,domain=sportowefakty.wp.pl
-||www.wp.pl/*EyGigSJQ01ETIaK*$subdocument,domain=komorkomania.pl

--- a/polish-adblock-filters/adblock_ublock.txt
+++ b/polish-adblock-filters/adblock_ublock.txt
@@ -6,26 +6,20 @@
 ! Wsparcie:
 !   Patronite ==> https://patronite.pl/polskiefiltry
 !   PayPal ==> https://www.paypal.com/pools/c/87zNJ8OJ3I
-! Last modified: 28 Febuary 2024
+! Last modified: 29 January 2025
 ! Expires: 1 day
-! Version: 2024022800
+! Version: 2025012902
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
 ! Redundant Checker >> https://www.certyficate.it/redundant_checker/redundantRuleChecker.html
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
-! Copyright © 2024 Certyficate IT
+! Copyright © 2025 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2024022800 aktualizacja: śro, 28 lutego 2024, 22:23
+! v.2025012901 aktualizacja: sr, 29 stycznia 2025, 17:05:00
 !
 !
 !--------------------------Rules only to uBlock-------------!
-! http://alltube.tv/
-! Ominięcie czekania
-alltube.tv###iframe-container:style(display: block !important;)
-alltube.tv###please-wait-container
-alltube.tv##+js(noeval)
-!
 ! http://www.czasbajki.pl/
 ! Ominięcie czekania
 czasbajki.pl###kAdd
@@ -73,15 +67,6 @@ cda.pl###kolumnaSrodkowa:style(height: auto !important;)
 cda.pl###obiekt:style(display: block !important;)
 ebd.cda.pl##+js(nowoif)
 !
-! pclab.pl
-!pclab.pl###header .left .sponT:style(height: 100px !important;)
-!pclab.pl###header .right .sponT:style(height: 75px !important;)
-!pclab.pl###headerwrapper:style(height: 140px !important;)
-!pclab.pl###categories:style(top: 33px !important;)
-!pclab.pl###header:style(z-index: 0 !important;)
-!pclab.pl###tabwrapper #tab:style(margin-top: 90px !important;)
-pclab.pl##.logoS:style(width: 275px; padding: 11px 0 0 5px; height: 74px; float: left;)
-||pclab.pl/css/extra
 !
 ! playpuls.pl
 ! Ominięcie reklam
@@ -269,8 +254,8 @@ streamin.to##+js(noeval-if, RTCPeerConnection)
 ! Popupy https://github.com/MajkiIT/polish-ads-filter/issues/2478
 ||go.onclasrv.com/apu.php$important,redirect=noop.js,script
 !
-! reklama po prawej np. na pclab.pl, onet.pl, businessinsider.com.pl, noizz.pl, komputerswiat.pl, plejada.pl
-auto-swiat.pl,businessinsider.com.pl,komputerswiat.pl,noizz.pl,onet.pl,pclab.pl,plejada.pl###nitro-block:style(position: absolute !important; left: -3000px !important;)
+! reklama po prawej np. na onet.pl, businessinsider.com.pl, noizz.pl, komputerswiat.pl, plejada.pl
+auto-swiat.pl,businessinsider.com.pl,komputerswiat.pl,noizz.pl,onet.pl,plejada.pl###nitro-block:style(position: absolute !important; left: -3000px !important;)
 !
 ! blokowanie gemius
 !||onet.hit.gemius.pl/fpdata.js$script,important
@@ -451,14 +436,6 @@ strabag-pfs.pl###page_margins:style(position: relative !important; margin: 0px a
 ekino-tv.pl##+js(nano-stb)
 swiatfilmow.com##+js(nano-stb, function, 1000, 0.02)
 !
-! Easylist Bugs
-!filmweb.pl##+js(aopw, sas)
-@@||addthis.com/live/*$script,domain=serialomaniak.pl
-||addthis.com/*/addthis_widget.js$badfilter,script
-||addthis.com/*/addthis_widget.js$script,domain=~serialomaniak.pl
-! uBO Privacy Bugs
-||addthis.com^$badfilter,important,third-party,domain=~missingkids.com|~missingkids.org|~sainsburys.jobs|~sitecore.com|~amd.com
-||addthis.com^$important,third-party,domain=~missingkids.com|~missingkids.org|~sainsburys.jobs|~sitecore.com|~amd.com|~serialomaniak.pl
 !
 ! IF rules
 !#if cap_html_filtering
@@ -583,7 +560,6 @@ tekstowo.pl#$#.teledysk { flex: 0 0 100% !important; max-width: 100% !important;
 meczyki.pl##:not(.onnetwork-banner) > .placeholder:not(.onnetwork-banner):style(height: 0 !important; min-height: 0 !important;)
 !
 ! uBlock-user
-!napiprojekt.pl##+js(insert-iframe, 1, honeypot, https://www.napiprojekt.pl/napisy-42731-Ostatni-U-Boot-(1993), width: 1px !important; height: 1px !important; position: absolute !important; left: -3000px !important)
 napiprojekt.pl##+js(ape, body #catalgForm, iframe, src, https://www.napiprojekt.pl/napisy-42731-Ostatni-U-Boot-(1993))
 napiprojekt.pl##body #catalgForm iframe[src*="U-Boot"]
 ppe.pl###hot-slides-wrapper #hot_0, #hot-slider #m_hot_0

--- a/polish-adblock-filters/polish_adblock.user.js
+++ b/polish-adblock-filters/polish_adblock.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name         wp.pl
-// @version      0.2
-// @description  Pozbycie siÄ™ reklam i komunikatu o adblocku na stronach naleÅ¼Ä…cych do wp.pl
+// @name         wp.pl - nieaktualny
+// @version      0.3
+// @description  Pozbycie się reklam i komunikatu o adblocku na stronach należących do wp.pl
 // @author       F4z
 // @match        *://*.abczdrowie.pl/*
 // @match        *://*.autokrata.pl/*
@@ -29,7 +29,9 @@
 // @downloadURL https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/polish_adblock.user.js
 // ==/UserScript==
 
-(function(b) {
+(function() {
+    'use strict';
+/* (function(b) {
     function a() {
         "advertisement" != arguments[0] && b.apply(window, arguments)
     }
@@ -51,4 +53,5 @@
             }
         }
     })
-})(window.addEventListener);
+})(window.addEventListener); */
+})();

--- a/polish-adblock-filters/polish_ads_wp.user.js
+++ b/polish-adblock-filters/polish_ads_wp.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name         Reklamy WP
+// @name         Reklamy WP - nieaktualny
 // @namespace    F4z
-// @version      0.5
+// @version      0.6
 // @description  Blokowanie reklam na wp.pl
 // @author       AdamWr + krystian3w 
 // @match        *://*.abczdrowie.pl/*
@@ -52,6 +52,9 @@
 // @updateURL    https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/polish_ads_wp.user.js
 // @downloadURL  https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/polish_ads_wp.user.js
 // ==/UserScript==
-Object.defineProperty(navigator, 'userAgent', {
+(function() {
+    'use strict';
+/* Object.defineProperty(navigator, 'userAgent', {
     value: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
-});
+}); */
+})();


### PR DESCRIPTION
* Usunięcie filtrów dla zamkniętego:
    
    * `addthis.com`/`serialomaniak.pl` (https://github.com/MajkiIT/polish-ads-filter/issues/8235 / https://github.com/uBlockOrigin/uAssets/issues/2764),
    *  `pclab.pl`,
    *  `forum.pcformat.pl`,
    *  `forum.komputerswiat.pl`,
    *  `alltube.tv`/`alltube.pl`,
    *  `efilmy.tv` (przekierowuje na martwy `filmix.es` (parking));

* Dezaktywacja używania przestarzałych skryptów do np. Tampemonkey;



<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 

Teoretycznie ktoś może odpalić dodatkowe machiny do usunięcia martwych domen z listy.
