### PR TITLE
Update 👍🏻 & 🍪 (2025.9.29) 

### DIFF
--- a/adblock_social_filters/adblock_social_list.txt
+++ b/adblock_social_filters/adblock_social_list.txt
@@ -6,8 +6,8 @@
 ! Required: Do poprawnego działania wymagana jest lista EasyList Social List (EasyList – Social Widgets) wraz z EasyList (Ads) lub AdGuard Base (w produktach AdGuard)!
 ! Collaborators: MajkiIT, blocker999, hawkeye116477, xxcriticxx, KonoromiHimaries, RikoDEV, krystian3w
 ! Homepage: https://www.certyficate.it/
-! Version: 2025.9.22.0
-! Last modified: Mon, 22 Sep 2025, 21:58 UTC+00:00
+! Version: 2025.9.29.0
+! Last modified: Mon, 29 Sep 2025, 16:58 UTC+00:00
 ! Expires: 2 days
 ! Support:
 !   Email => errorsfilters@certyficate.it
@@ -18,7 +18,7 @@
 ! Copyright © 2025 Certyficate IT
 ! Copyright © 2025 Filters Heroes
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock/
-! v.2025.9.22.0 aktualizacja: pon, 22 wrz 2025, 21:58 UTC+00:00
+! v.2025.9.29.0 aktualizacja: pon, 29 wrz 2025, 16:58 UTC+00:00
 !
 !
 !#safari_cb_affinity(social)
@@ -863,7 +863,7 @@ pl,tv##div#facebook-comments[class] > a.comments-facebook[href="#"]
 2xme.pl##.footer__block--flex.footer__block, .media__second
 3dfilamenty.com,flowerexpress.pl##.fx-social
 3dom.pro##.division-size-50.division-box-2.division-box
-3dom.pro,abarta.pl,anmur.eu,bedziepieklo.pl,centrumhandlowerobi.pl,gardenflora.pl,graszki.pl,home-sklep.pl,homedoors.eu,homehood.eu,hydrosan.eu,kubolek.pl,mbmeganarzedzia.pl,media-tech.eu,motogron.com,narzedziowy24.eu,pasmanteria.eu,ss24.pl,stolmot.com,thebookshop.pl,tkaninyflorentine.pl,upominki24.pl,wik-tor.pl#?#.footer-container div .center.section-title > span:has-text(Znajdziesz nas na)
+3dom.pro,abarta.pl,anmur.eu,bedziepieklo.pl,centrumhandlowerobi.pl,gardenflora.pl,graszki.pl,home-sklep.pl,homedoors.eu,hydrosan.eu,kubolek.pl,mbmeganarzedzia.pl,media-tech.eu,motogron.com,narzedziowy24.eu,pasmanteria.eu,ss24.pl,stolmot.com,thebookshop.pl,tkaninyflorentine.pl,upominki24.pl,wik-tor.pl#?#.footer-container div .center.section-title > span:has-text(Znajdziesz nas na)
 3dom.pro,allekki.pl,beyco.pl,bombkisklep.pl,butdam.sklep.pl,chataskrzata.eu,czerwonak.pl,ekoforemki.pl,infobowling.pl,sklepblawatny24.pl,slet24.pl,szkola-jazdy.pl,zikom.pl###fb-side-like
 3dom.pro,anmur.eu##.top-bar li:nth-of-type(n+3) > .link
 3gibbons.com##.menu_button_wrapper > a[href*="facebook.com/3gibbonscom"]
@@ -1107,7 +1107,7 @@ agronews.com.pl,eurowizja.org,gazetaregionalna.com,gizycko.info,kurier-kolejowy.
 agroperfekt.pl##.rssocial-custom-icon[href*="instagram.com/"]
 agroperfekt.pl,apolanka.pl,bona-ppetit.pl,kam-tech.com.pl,mckenzie.pl,owbaltyk.pl,rolpolopalenica.pl,rozruch-startgum.pl##.rssocial-facebook-icon
 agroperfekt.pl,czemarol.pl,materialybudowlanekrokowa.pl,owbaltyk.pl##.rssocial-youtube-icon
-agropolska.pl,avatec.pl,bitdefender.pl,canagri.pl,carsmile.pl,cpl.com,cyclonis.com,deere.pl,delphiautoparts.com,ekipatonosi.pl,ekogram.pl,empireshop.pl,eobuwie.com.pl,etuo.pl,forums.lenovo.com,garneczki.pl,genzie.store,heel.pl,infinixstore.eu,kajto.pl,klaudynahebda.pl,kreatywna.pl,lilio.pl,logitech.com,lokalnyrolnik.pl,lumex.pl,makro.pl,mi-home.pl,morebananas.pl,nano.komputronik.pl,netgear.com,one.greeneris.com,papatka.pl,pekao.com.pl,pieknoumyslu.com,polskieradio24.pl,pomagam.pl,proformat.pl,przemekjurek.pl,radioq.fm,saketos.pl,sklep.miod.com.pl,sumin.com.pl,support.avast.com,tarczynskiarenawroclaw.pl,teb.pl,velux.pl,virtu.com.pl,wciagnij.to,webd.pl,weissklinik.pl,wingsbridge.pl,xlm.pl,zinfo.pl,zjedz.my##.social-icons
+agropolska.pl,avatec.pl,bitdefender.pl,canagri.pl,carsmile.pl,cpl.com,cyclonis.com,deere.pl,delphiautoparts.com,ekipatonosi.pl,ekogram.pl,empireshop.pl,eobuwie.com.pl,etuo.pl,forums.lenovo.com,garneczki.pl,genzie.store,heel.pl,infinixstore.eu,kajto.pl,klaudynahebda.pl,kreatywna.pl,lilio.pl,logitech.com,lokalnyrolnik.pl,lumex.pl,makro.pl,mi-home.pl,morebananas.pl,nano.komputronik.pl,naszaklasa.app,netgear.com,one.greeneris.com,papatka.pl,pekao.com.pl,pieknoumyslu.com,polskieradio24.pl,pomagam.pl,proformat.pl,przemekjurek.pl,radioq.fm,saketos.pl,sklep.miod.com.pl,sumin.com.pl,support.avast.com,tarczynskiarenawroclaw.pl,teb.pl,velux.pl,virtu.com.pl,wciagnij.to,webd.pl,weissklinik.pl,wingsbridge.pl,xlm.pl,zinfo.pl,zjedz.my##.social-icons
 agrosiec.pl##.fixed > a[href*=".com/"][target="_blank"]
 agrosimex.pl##.icon-Youtube
 agrosimex.pl##a.social-icon
@@ -1863,10 +1863,11 @@ biuroprasowe.pl##.clr:has(~ #share_cont)
 biuroprasowe.pl##.epr_social .tw
 biuroprasowe.pl##.twt, .lin
 biuroprasowe.play.pl##.footer__icons-container > li:not(:nth-of-type(6))
-biuroprasowe.porta.com.pl##.pr-story--share-sapce
-biuroprasowe.porta.com.pl##.pr-story--share-sapce-lead
+biuroprasowe.porta.com.pl,media.globalworth.pl,media.traficar.pl,prowly.com##.flex--right > .pr-story--share-text
+biuroprasowe.porta.com.pl,media.globalworth.pl,media.traficar.pl,prowly.com##.pr-story--media-contact__social-icon
+biuroprasowe.porta.com.pl,media.globalworth.pl,media.traficar.pl,prowly.com##.pr-story--share-sapce
+biuroprasowe.porta.com.pl,media.globalworth.pl,media.traficar.pl,prowly.com##.pr-story--share-sapce-lead
 biuroprasowe.porta.com.pl,media.globalworth.pl,media.traficar.pl,prowly.com##.pr-story--share-sapce-none
-biuroprasowe.porta.com.pl,media.traficar.pl##.flex--right > .pr-story--share-text
 bivert.pl##.social-absolute
 bizhub24.pl##.widget_times_social_widget.bass.widget a:not([href*="podcasts.google"])
 bizhub24.pl##.widget_times_social_widget.bass.widget h2
@@ -4254,6 +4255,7 @@ home.morele.net,scroll.morele.net##.footer-social-section
 home.morele.net,scroll.morele.net##.post-below-interactions-share
 home.morele.net,scroll.morele.net##.post-sidebar-share
 home.pl##.o-page-footer__column:nth-of-type(5)
+home.pl##footer a[href*=".com/"][title^="Przejdź na "]
 home.pl##footer a[title="Linkedin"]
 home.pl##footer a[title="Youtube"]
 home.pl,pl.tripadvisor.com##footer a[title="Facebook"]
@@ -4280,6 +4282,7 @@ horecabc.pl##.et_pb_image > a[href*="facebook.com/groups/horecabc/"]
 horecatrends.pl##.artInsta
 horecatrends.pl##.soc, .tabs-1
 horex.pl##.newsletter__social_media
+hormann.pl##.c-social-media
 horsklep.pl,kastor-bike.pl,voronet.pl###widget_shop5
 hortens.pl##div.footer_block.links:nth-of-type(3) > h3
 horyzont.eu##.custom > ul > li:nth-of-type(n+3):nth-of-type(-n+4)
@@ -5621,8 +5624,6 @@ media.carrefour.pl##.footer__social__list
 media.globalworth.pl##.flex--right .pr-story--share-text
 media.ing.pl##div.column:nth-of-type(2) .footer-section-text, div.column:nth-of-type(2) .footer-section-text ~ ul > li
 media.pkobp.pl##.pko-menu__social-icons > .pko-icon:not(.pko-icon--rss)
-media.upc.pl##.pr-story--media-contact__social-icon
-media.upc.pl##div[class*="pr-story-share--"] > div > div[class*="right"], div[class*="pr-story--share-s"]
 mediaarena.pl,sklep.amw.com.pl###fx-fb
 mediaexpert.pl##.is-shareButtonsContainer
 mediafire.com##.ShareDialog-socialLinks
@@ -6568,6 +6569,9 @@ p.lodz.pl##.FacebookBox
 paa.gov.pl##.pole-banerowe > a[href*="twitter.com/paatomistyki"]
 paatal.pl###footer_links #menu_buttons3
 paclan.pl#?#.bottomboxes:has-text(Złap nas w sieci)
+paczkasmaku.pl##.footer-company .div-block-8
+paczkasmaku.pl##.footer-company .text-block-3-copy
+paczkasmaku.pl##li.menu-item-desktop:has(> a[href*="facebook.com"])
 paczki.zabka.pl##.footer-social li:has(a:not([href*="/kontakt"]))
 paczki.zabka.pl#?#footer h6:has-text(Dowiedz się więcej)
 paczkow.pl##.promo-links-facebook
@@ -8418,6 +8422,7 @@ store.canon.pl##.primary-social-icons
 store.steampowered.com##.linkbar:has(.social_account)
 store.steampowered.com##a[class^="discussionwidget_ShareBtn_"]
 store.steampowered.com##a[onclick^="ShowShareDialog"]
+store.steampowered.com##dialog div[class*="Share_Dialog"] form[role="dialog"] > div:nth-child(2) > div:first-child > div:nth-child(2)
 stormmedia.gg##.absolute ~ div a[href="/"] ~ div a[class*="scale-125"][href*=".com/"]
 storytel.com###footerComponent > div > div:nth-of-type(2), a[href*="facebook.com/storytelPL"], a[href*="instagram.com/storytel.pl"]
 stozekwisla.pl##.col-xs-12.col-sm-7
@@ -8467,6 +8472,7 @@ stv.info#?#.td-footer-wrap .tdm-title-md.tdm-title:has-text(OBSERWUJ NAS)
 styl-sklep.pl##.ikona-fb.ikony-boczne
 styl-sklep.pl##.ikona-pi.ikony-boczne
 styl-sklep.pl##a[href*="facebook.com/STYL-Studio-"] > img
+styldladomu.pl###footgroup7 > ul > li:nth-child(4)
 stylovy.pl##.header-flex-left
 subiektywnieofinansach.pl##.et-social-instagram
 suchylas.pl#?#.jPanel:has(h3:has-text(/FB|YouTube/))

--- a/cookies_filters/adblock_cookies.txt
+++ b/cookies_filters/adblock_cookies.txt
@@ -6,8 +6,8 @@
 ! Required: Do poprawnego działania wymagana jest lista EasyList Cookie List (EasyList - Cookie Notices) wraz z EasyList (Ads) lub AdGuard Base (w produktach AdGuard)!
 ! Collaborators: MajkiIT, F4z, xxcriticxx, blocker999, hawkeye116477, krystian3w
 ! Homepage: https://www.certyficate.it/
-! Version: 2025.9.22.0
-! Last modified: Mon, 22 Sep 2025, 21:58 UTC+00:00
+! Version: 2025.9.29.0
+! Last modified: Mon, 29 Sep 2025, 16:58 UTC+00:00
 ! Expires: 2 days
 ! Support:
 !   Email => errorsfilters@certyficate.it
@@ -19,7 +19,7 @@
 ! Copyright © 2025 Certyficate IT
 ! Copyright © 2025 Filters Heroes
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock/
-! v.2025.9.22.0 aktualizacja: pon, 22 wrz 2025, 21:58 UTC+00:00
+! v.2025.9.29.0 aktualizacja: pon, 29 wrz 2025, 16:58 UTC+00:00
 !
 !
 ! Specyficzne filtry ukrywające
@@ -688,6 +688,7 @@ colormark.pl###Kom_cookie
 comfortum.pl,dywany.dywilan.pl,powiatkutno.eu,umed.pl###ppc_box.ppc_box
 comitor.pl###rodoBoxWrap
 confronter.pl###cookieBarDiv
+console.cloud.google.com##.glue-cookie-notification-bar
 consumer.huawei.com##.huawei-bootom-cookie
 contentorganica.pl##.pasekBlack
 contentstream.pl,events.teams.microsoft.com,niezlasztuka.net###cookie-banner
@@ -3480,6 +3481,7 @@ pl/tcf/cookie.js$script,domain=pl
 ~pl###kopageBarCookies:lang(pl)
 ~pl###x13eucookies-icon:lang(pl)
 ~pl##.fmessages:lang(pl):has(.cookie-message-popup-lq, .cookie-notice-ui)
+~pl##a[href="javascript:CookieScript.instance.show()"]:lang(pl)
 ~pl##body > div#cookie[class=""]
 ~pl##body:not([class*="cookie-overflow"], [class*="freeze_bcg"]) #ck_dsclr:lang(pl)
 ~pl##body:not([class*="cookie-overflow"], [class*="freeze_bcg"]) div[id][class*="iai_cookie"]:lang(pl)
@@ -4160,6 +4162,7 @@ pl##.wrap-cookie-info:not(body, html)
 pl##[class*="cookie-policy"]:not(body, html)
 pl##[class^="box-cookie"]:not(body, html)
 pl##[id^="topInfo"]:not(body, html)
+pl##a[href*="javascript:CookieScript.instance.show()"]
 pl##aside[class*="Cookie"]
 pl##aside[class*="cookie"]:not([class*="modal" i])
 pl##body > div[style*="top"][style*="left"][style*="background"][style*="cookies_tlo"]:not([id], [class])
@@ -4422,6 +4425,7 @@ polska6.pl###modal { remove: true }
 purepc.pl##.cookiesinfo { remove: true }
 rynek-turystyczny.pl###modal-rodo { remove: true }
 vinello.pl##dialog#cookieDialog { remove: true }
+webh.pl##body .cookie-consent { remove: true }
 wmglass.com.pl##dialog[cookies-dialog] { remove: true }
 !#endif
 !
@@ -4488,11 +4492,12 @@ publiczneodtwarzanie.pl,urbancity.pl#@##cookie-modal:not(body, html, .reveal)
 puratos.pl#@##cookieInfo:not(body, html)
 selgros.pl#@##cookie_accept:not(body, html)
 sklep-domwhisky.pl#@#.rodo-popup:not(body, html, [style="display: block;"])
-sklep.winkhaus.pl,volcano.pl#@#aside[class*="cookie"]:not([class*="modal" i])
+sklep.winkhaus.pl,volcano.pl,webh.pl#@#aside[class*="cookie"]:not([class*="modal" i])
 smsapi.pl#@#body:not([style*="overflow"]) #CybotCookiebotDialog
 stilord.pl#@#.cookie-bar:not(body, html)
 uniabracka.pl#@#body:not(.cookie-opened) #cookie-container
 visa.pl#@#span[class*="Cookie"]:not(.closeCookie, [class*="CookiebotDialog"])
+webh.pl#@#.cookie-consent:not(body, html, .paragraph)
 wtk.pl#@#.privacy-container:not(body, html, .content-container)
 !
 !

--- a/cookies_filters/cookies_uB_AG.txt
+++ b/cookies_filters/cookies_uB_AG.txt
@@ -832,6 +832,7 @@ wearmedicine.com##.modal--open:style(position: static !important; overflow-y: au
 wearmedicine.com##.modal:has(div[class*="Cookies"])
 wearmedicine.com##div[class*="CookiesConsentPopUp"], div[class*="cookiesInfoModal"]
 wearmedicine.com##div[class*="newModal" i]:has(div[class*="CookiesConsentPopUp"], div[class*="cookiesInfoModal"])
+webh.pl##body .cookie-consent:remove()
 webhelp.pl###wrapper:style(margin-top: auto !important)
 webprojekt.biz###rodo, #screenMoire
 webprojekt.biz##.no-move:style(overflow-y: auto !important)


### PR DESCRIPTION
Głównie poprawka pod [`webh.pl`](https://adguardteam.github.io/AnonymousRedirect/redirect.html?url=https://webh.pl "w nowoczesnych przeglądarkach zablokowali przewijanie, a niewielu upiera się na PaleMoon, Basilisk, Firefox 52-120, Chrome 49-104, Safari 15-15.3").

---

FYI @MajkiIT / @xxcriticxx.