### PR TITLE
Update hostfile.txt

### DIFF
--- a/polish-pihole-filters/hostfile.txt
+++ b/polish-pihole-filters/hostfile.txt
@@ -1,11 +1,11 @@
-#202407220001
+#20251202195201
 # Polish filters for Pi hole
 # Collaborators: xxcriticxx, MajkiIT
 # Homepage: https://www.certyficate.it/
 # Contact: errorsfilters@certyficate.it 
 # Support: https://github.com/MajkiIT/polish-ads-filter/issues
 # License: https://creativecommons.org/licenses/by-nc-sa/4.0/
-# Copyright (C) 2024 Certyficate IT
+# Copyright (C) 2025 Certyficate IT
 #
 #
 # [certyficate.it]
@@ -298,7 +298,7 @@
 0.0.0.0 salesbeehive.com
 0.0.0.0 smartclick.pl
 0.0.0.0 smpl.hit.ppdb.pl
-0.0.0.0 snrbox.com
+# 0.0.0.0 snrbox.com
 0.0.0.0 snrcdn.net
 0.0.0.0 stat.4u.pl
 0.0.0.0 stat.dziennik.pl


### PR DESCRIPTION
#23181

dalsza naprawa może wymagać zrobienia listy subdomen bezpiecznych do blokady w składni HOSTS i użycia lepszego pliku dla repozytorium AdGuard HOSTS lists dla ich projektu o mocy Pi-Hole.

<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
