### PR TITLE
Update adblock.txt

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -7,9 +7,9 @@
 ! Works best with EasyList - be sure to subscribe it as well!
 ! Działa najlepiej z EasyList - pamiętaj aby zasubskrybować!
 !   Patronite ==> https://patronite.pl/polskiefiltry
-! Last modified: 24 June 2026
+! Last modified: 12 July 2026
 ! Expires: 1 day
-! Version: 2026062402
+! Version: 2026071200
 ! Support:
 !   Email >> errorsfilters@certyficate.it
 !   Github >> https://github.com/MajkiIT/polish-ads-filter/issues
@@ -17,7 +17,7 @@
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright © 2026 Certyficate IT
 ! Najnowsza wersja zawsze na: https://www.certyficate.it/adblock
-! v.2026062402 aktualizacja: sr, 24 czerwca 2026, 15:00:00
+! v.2026071200 aktualizacja: nie, 12 lipca 2026, 12:20
 !
 !
 !1#-----------------------General advert blocking filters-----------------------!
@@ -584,6 +584,7 @@ biztok.pl,teleshow.wp.pl,gwiazdy.wp.pl,moto.wp.pl,wiadomosci.wp.pl,money.pl,tury
 blado.pl##span[style^="font-size: 15"] > center, h2[style^="font-size: 14"] > center
 blasty.pl##.ads_top_of_list
 blaugrana.pl##[class^="gridAd"]
+blik.com###advertise_left.advertise_left, #advertise_right.advertise_right
 blog.nowebrzmienia.pl###text-2 > .widget-title-container
 blog.pluralsight.com##.video.widescreen.flex-video
 blogbukmacherski.pl###stream-item-widget-3 > .stream-item-widget-content
@@ -1711,6 +1712,7 @@ inowroclaw.info.pl##.row:nth-of-type(4) > .fl.w250, div.l-container > div.l-row 
 inowroclaw.info.pl##CENTER > A > IMG
 inpost.pl##.after-search-banner.topbannerresultsSearch
 instalacjebudowlane.pl###belka, #panel
+instalki.pl##center:has(span)
 instalki.pl###PushangoAlert, #Mod359
 instalki.pl###banner
 instalki.pl##DIV > DIV[style^="width: 90%; padding: 15px"]
@@ -5118,8 +5120,6 @@ www.wirtualnemedia.pl###wtg_art_full_service
 @@||gazetabilgoraj.pl/wp-content/plugins/better-adsmanager/js/advertising.min.js$script
 @@||go.eu.bbelements.com/please/code|$domain=filmweb.pl
 @@||google-analytics.com^$domain=certyficate.it|liptonicetea.com|filmweb.pl|aptekarski.com
-@@||googletagmanager.com/gtag/$script,domain=certyficate.it|aptekarski.com
-@@||googletagmanager.com/gtm.js$script,domain=www.emag.pl|benchmark.pl|komputerswiat.pl|www.jabra.pl|plus.pl|expressilustrowany.pl|motofakty.pl|kurierlubelski.pl|stronakobiet.pl|ads.allegro.pl|skoda-auto.pl|aptekarski.com
 @@||googletagservices.com/tag/js/gpt.js$script,domain=wprost.pl
 @@||guce.advertising.com/collectIdentifiers?sessionId=
 @@||hit.gemius.pl/gplayer.js$script,domain=polotv.pl|pilot.wp.pl
@@ -6062,25 +6062,26 @@ avanti24.pl,czterykaty.pl,edziecko.pl,g.pl,gazeta.pl,haps.pl,hapsvod.pl,magazyn-
 ||extcdn.burdamedia.pl$script
 !
 !49#--------------------------EasyPrivacy Bugs------------!
-@@||tv.wp.pl/do/*/dotn?sw=$image,~third-party,domain=tv.wp.pl
-@@||staty.portalradiowy.pl/wstats/wstats.php$script,domain=discoparty.pl|discopolonew.cba.pl
+@@||ceneo.pl/Scripts/dist/Desktop/base/custom/Basket/analytics.js$script,domain=ceneo.pl
+@@||exacttarget.com/CloudPages/lib/smartcapture-formjs.js$script,domain=cloud.polska.auchan.pl
 @@||fastwhitecat.com/wp-content/plugins/duracelltomi-google-tag-manager/js/gtm4wp-download-tracker.js
 @@||get.x-link.pl/$subdocument,domain=dziendobry.tvn.pl
-@@||www.googletagmanager.com/gtag/js$script,domain=www.geselle.pl|heydoc.pl
-@@||www.google-analytics.com/analytics.js$script,domain=www.geselle.pl|aptekarska.pl
-@@||www.google-analytics.com/gtm/js$script,domain=www.geselle.pl|aptekarska.pl
-@@||ceneo.pl/Scripts/dist/Desktop/base/custom/Basket/analytics.js$script,domain=ceneo.pl
-@@||www.googletagmanager.com/gtm.js$script,domain=www.mbank.pl
-@@||online.mbank.pl/venezia/fingerprint.js$script,domain=online.mbank.pl
-@@||ts.tradetracker.net/?cid=$image,domain=ksiegarnia-edukacyjna.pl
-@@||ticket.energylandia.pl/static/prod/scripts/modules/analytics.js$script,domain=ticket.energylandia.pl
-@@||wpfc.ml^$domain=kryminalnapolska.pl
-@@||exacttarget.com/CloudPages/lib/smartcapture-formjs.js$script,domain=cloud.polska.auchan.pl
-@@||smushcdn.com/*/blank.gif$image,domain=bithub.pl
-@@||polfan.pl/*/fingerprint2.min.js$script,~third-party,domain=polfan.pl
-@@||googletagmanager.com^$script,domain=www.aptekarska.pl|aptekarski.com
+@@||google-analytics.com/analytics.js$script,domain=www.geselle.pl|aptekarska.pl
+@@||google-analytics.com/gtm/js$script,domain=www.geselle.pl|aptekarska.pl
 @@||google-analytics.com^$domain=www.aptekarska.pl|aptekarski.com
-@@||www.googletagmanager.com/gtm.js$script,domain=geselle.pl
+@@||googletagmanager.com/gtag/js$script,domain=www.geselle.pl|heydoc.pl
+@@||googletagmanager.com/gtag/$script,domain=certyficate.it|aptekarski.com
+@@||googletagmanager.com/gtm.js$script,domain=www.emag.pl|benchmark.pl|komputerswiat.pl|www.jabra.pl|plus.pl|expressilustrowany.pl|motofakty.pl|kurierlubelski.pl|stronakobiet.pl|ads.allegro.pl|skoda-auto.pl|aptekarski.com|geselle.pl|www.mbank.pl|krzyzowki123.pl
+@@||googletagmanager.com/gtm.js$xmlhttprequest,domain=krzyzowki123.pl
+@@||googletagmanager.com^$script,domain=www.aptekarska.pl|aptekarski.com
+@@||online.mbank.pl/venezia/fingerprint.js$script,domain=online.mbank.pl
+@@||polfan.pl/*/fingerprint2.min.js$script,~third-party,domain=polfan.pl
+@@||smushcdn.com/*/blank.gif$image,domain=bithub.pl
+@@||staty.portalradiowy.pl/wstats/wstats.php$script,domain=discoparty.pl|discopolonew.cba.pl
+@@||ticket.energylandia.pl/static/prod/scripts/modules/analytics.js$script,domain=ticket.energylandia.pl
+@@||ts.tradetracker.net/?cid=$image,domain=ksiegarnia-edukacyjna.pl
+@@||tv.wp.pl/do/*/dotn?sw=$image,~third-party,domain=tv.wp.pl
+@@||wpfc.ml^$domain=kryminalnapolska.pl
 @@||www.cloudflare.com/cdn-cgi/trace$domain=plus.pl|polsatbox.pl
 !
 !50#--------------------------Video Players------------!


### PR DESCRIPTION
- fix #23438
- drobne sortowanie filtrów sieciowych na bugi EasyPrivacy/EasyList
- ukrycie reklam na finalizacji blik.com (`e.blik.com`)
- drobna walka z reklamami instalki.pl (na granicy reklamy wewnętrznej, tyle że to wideo sponsorowane)


<!--
Dziękujemy za działanie na rzecz Polskich Filtrów Adblock & uBlock
Przed podjęciem jakiegokolwiek działania koniecznie zapoznaj się z CONTRIBUTING.md
--> 
